### PR TITLE
Change default fail state of Short-Range Telephone in CraftingService…

### DIFF
--- a/src/Service/PetActivity/CraftingService.php
+++ b/src/Service/PetActivity/CraftingService.php
@@ -1875,7 +1875,7 @@ class CraftingService
         }
         else
         {
-            $activityLog = PetActivityLogFactory::createUnreadLog($this->em, $pet, '%pet:' . $pet->getId() . '.name% tried to make a bow out of an L-Square, but, ironically, couldn\'t get the measurements right.')
+            $activityLog = PetActivityLogFactory::createUnreadLog($this->em, $pet, '%pet:' . $pet->getId() . '.name% tried to connect two plastic "cans", but the string kept getting tangled.')
                 ->setIcon('icons/activity-logs/confused')
                 ->addTags(PetActivityLogTagHelpers::findByNames($this->em, [ PetActivityLogTagEnum::Crafting, PetActivityLogTagEnum::Location_At_Home ]))
             ;


### PR DESCRIPTION
….php

failure state of Ribbeley's Composite was accidentally copied into the final else statement of the Short-Range Telephone's crafting dialogue, resulting in bug 21

the fail dialogue is placeholder