### PR TITLE
change "Umbra" skill to "Arcana" in Vesica Hydragyrum quest text

### DIFF
--- a/src/Service/PetActivity/PhilosophersStoneService.php
+++ b/src/Service/PetActivity/PhilosophersStoneService.php
@@ -196,7 +196,7 @@ class PhilosophersStoneService
 
             $activityLog = PetActivityLogFactory::createUnreadLog($this->em,
                 $pet,
-                'The Ceremony of Fire lead ' . ActivityHelpers::PetName($pet) . ' to an ice cave in the frozen quag in the Umbra, blocked by huge, Everice icicles. The Ceremony of Fire quivered in ' . ActivityHelpers::PetName($pet) . '\'s hands, but they had no idea how to use it, so returned home and put it away. (Perhaps more Umbra skill would help?)'
+                'The Ceremony of Fire lead ' . ActivityHelpers::PetName($pet) . ' to an ice cave in the frozen quag in the Umbra, blocked by huge, Everice icicles. The Ceremony of Fire quivered in ' . ActivityHelpers::PetName($pet) . '\'s hands, but they had no idea how to use it, so returned home and put it away. (Perhaps more Arcana skill would help?)'
             );
 
             EquipmentFunctions::unequipPet($pet);


### PR DESCRIPTION
update the Ceremony of Fire "too little arcana" message to read Arcana skill instead of Umbra skill

with Umbra returning as a skill that can be granted by tools, and Arcana being the actual name of the used skill, I think it's more clear to newer players what is meant by this message and that the pet's default Arcana should be leveled