### PR TITLE
Fix helper & shelter choice dialogs being in notes

### DIFF
--- a/webapp/src/app/module/pet-helpers/dialog/interact-with-away-pet/interact-with-away-pet-dialog.component.html
+++ b/webapp/src/app/module/pet-helpers/dialog/interact-with-away-pet/interact-with-away-pet-dialog.component.html
@@ -20,6 +20,15 @@
           <p><app-loading-throbber /></p>
         }
         @else if(pet) {
+          @if(choices.length > 0)
+          {
+            <p class="buttons">
+              @for (choice of choices; track choice.value) {
+                <button (click)="doMakeChoice(choice)">{{ choice.label }}</button>
+              }
+            </p>
+            <hr>
+          }
           <app-pet-status-effects-tab [pet]="pet" (onNavigate)="doClose()" />
         }
       </div>
@@ -78,15 +87,6 @@
     @else if(tab === 'note')
     {
       <div [class.disabled]="loading">
-        @if(choices.length > 0)
-        {
-          <p class="buttons">
-            @for (choice of choices; track choice.value) {
-              <button (click)="doMakeChoice(choice)">{{ choice.label }}</button>
-            }
-          </p>
-          <hr>
-        }
         <app-pet-notes [(pet)]="pet" (loading)="doLoading($event)" (done)="doClose()" />
       </div>
     }

--- a/webapp/src/app/module/pet-shelter/dialog/interact-with-pet-shelter-pet/interact-with-pet-shelter-pet.dialog.html
+++ b/webapp/src/app/module/pet-shelter/dialog/interact-with-pet-shelter-pet/interact-with-pet-shelter-pet.dialog.html
@@ -20,7 +20,7 @@
   <div class="dialog-body">
     @if(tab === 'status')
     {
-        <div>
+      <div>
         @if(!pet && loading)
         {
           <p><app-loading-throbber /></p>
@@ -38,7 +38,7 @@
           }
           <app-pet-status-effects-tab [pet]="pet" (onNavigate)="doClose()" />
         }
-        </div>
+      </div>
     }
     @else if(tab === 'logs')
     {

--- a/webapp/src/app/module/pet-shelter/dialog/interact-with-pet-shelter-pet/interact-with-pet-shelter-pet.dialog.html
+++ b/webapp/src/app/module/pet-shelter/dialog/interact-with-pet-shelter-pet/interact-with-pet-shelter-pet.dialog.html
@@ -20,7 +20,25 @@
   <div class="dialog-body">
     @if(tab === 'status')
     {
-      <app-pet-status-effects-tab [pet]="pet" (onNavigate)="doClose()" />
+        <div>
+        @if(!pet && loading)
+        {
+          <p><app-loading-throbber /></p>
+        }
+        @else if(pet) {
+          @if(choices.length > 0)
+          {
+            <p class="buttons">
+              @for(choice of choices; track $index)
+              {
+                <button (click)="doMakeChoice(choice)">{{ choice.label }}</button>
+              }
+            </p>
+            <hr>
+          }
+          <app-pet-status-effects-tab [pet]="pet" (onNavigate)="doClose()" />
+        }
+        </div>
     }
     @else if(tab === 'logs')
     {
@@ -76,16 +94,6 @@
     @else if(tab === 'note')
     {
       <div [class.disabled]="loading">
-        @if(choices.length > 0)
-        {
-          <p class="buttons">
-            @for(choice of choices; track $index)
-            {
-              <button (click)="doMakeChoice(choice)">{{ choice.label }}</button>
-            }
-          </p>
-          <hr>
-        }
         <app-pet-notes [(pet)]="pet" (loading)="doLoading($event)" (done)="doClose()" />
       </div>
     }


### PR DESCRIPTION
Title.

Being in notes was unintuitive and made them easy to miss (and prob was a relic of notes being the first tab for a bit?)

### Implementation

Moved the bits in the HTML into the status tabs. For shelter pets I added a check for loading just in case it was needed (since it was in the helper pet dialog stuff)