### PR TITLE
Self-reflection merits

### DIFF
--- a/api/migrations/2026/05/Version20260506094100.php
+++ b/api/migrations/2026/05/Version20260506094100.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the Poppy Seed Pets API.
+ *
+ * The Poppy Seed Pets API is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * The Poppy Seed Pets API is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with The Poppy Seed Pets API. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260506094100 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Adds self-reflection merits';
+    }
+
+    public function up(Schema $schema): void
+    {
+        //Merits
+        $this->addSql(<<<EOSQL
+        INSERT INTO `merit` (`id`, `name`, `description`) VALUES (NULL, 'Of Heart and Mind', '%pet.name% understands their heart well, and gains more exp while they feel very loved.')
+        ON DUPLICATE KEY UPDATE `id` = `id`;
+        EOSQL);
+
+        $this->addSql(<<<EOSQL
+        INSERT INTO `merit` (`id`, `name`, `description`) VALUES (NULL, 'Precious Memories', '%pet.name% values their time spent with you! When they participate in quality time, they gain an item from the <a href="/poppyopedia/item?filter.itemGroup=Precious%20Memories">Precious Memories</a> item group.')
+        ON DUPLICATE KEY UPDATE `id` = `id`;
+        EOSQL);
+
+        $this->addSql(<<<EOSQL
+        INSERT INTO `merit` (`id`, `name`, `description`) VALUES (NULL, 'Second Stomach', '%pet.name% can eat past their normal stomach capacity, but only for their favorite foods!')
+        ON DUPLICATE KEY UPDATE `id` = `id`;
+        EOSQL);
+
+        //Item group assignment
+        //TODO
+    }
+
+    public function down(Schema $schema): void
+    {
+    }
+}

--- a/api/src/Entity/Pet.php
+++ b/api/src/Entity/Pet.php
@@ -728,10 +728,11 @@ class Pet
 
         if($fullness >= 0.75)
         {
+            $overstuffedMessage = $fullness > 1.0 ? 'over' : '';
             if($this->getSpecies()->getFamily() === 'fish')
-                return 'stuffed to the gills';
+                return $overstuffedMessage . 'stuffed to the gills';
             else
-                return 'stuffed';
+                return $overstuffedMessage . 'stuffed';
         }
         else if($fullness >= 0.50)
             return 'full';
@@ -834,12 +835,13 @@ class Pet
             return 'none';
     }
 
-    public function getStomachSize(): int
+    public function getStomachSize(bool $countSecondStomach = false): int
     {
         return
             $this->stomachSize +
             ($this->hasMerit(MeritEnum::BLACK_HOLE_TUM) ? 6 : 0) +
-            ($this->hasMerit(MeritEnum::GOURMAND) ? 4 : 0)
+            ($this->hasMerit(MeritEnum::GOURMAND) ? 4 : 0) +
+            ($countSecondStomach && $this->hasMerit(MeritEnum::SECOND_STOMACH) ? 10 : 0)
         ;
     }
 

--- a/api/src/Entity/Pet.php
+++ b/api/src/Entity/Pet.php
@@ -410,7 +410,7 @@ class Pet
         return -16;
     }
 
-    public function increaseFood(int $amount, ?int $max = null): self
+    public function increaseFood(int $amount, ?int $max = null, bool $secondStomach = false): self
     {
         if($amount === 0) return $this;
         if($max && $amount > 0 && $this->food >= $max) return $this;
@@ -418,7 +418,7 @@ class Pet
         $this->food = NumberFunctions::clamp(
             $this->food + $amount,
             $this->getMinFood(),                                    // minimum
-            $max ?? $this->getStomachSize() - max(0, $this->junk)   // maximum
+            $max ?? $this->getStomachSize($secondStomach) - max(0, $this->junk)   // maximum
         );
 
         return $this;
@@ -612,9 +612,9 @@ class Pet
         return $this->junk;
     }
 
-    public function increaseJunk(int $amount): self
+    public function increaseJunk(int $amount, bool $secondStomach = false): self
     {
-        $this->junk = NumberFunctions::clamp($this->junk + $amount, 0, $this->getStomachSize() - max(0, $this->food));
+        $this->junk = NumberFunctions::clamp($this->junk + $amount, 0, $this->getStomachSize($secondStomach) - max(0, $this->food));
 
         return $this;
     }

--- a/api/src/Enum/MeritEnum.php
+++ b/api/src/Enum/MeritEnum.php
@@ -103,4 +103,10 @@ final class MeritEnum
     public const string DOPPEL_GENE = 'Doppel Gene'; // always gives birth to twins
     public const string FAIRY_GODMOTHER = 'Fairy Godmother';
     public const string RUMPELSTILTSKINS_CURSE = 'Rumpelstiltskin\'s Curse'; // gold instead of wheat, and vice-versa
+
+    // through self-reflection points, only:
+    public const string OF_HEART_AND_MIND = 'Of Heart and Mind'; // gains more experience if love is at 'very loved'
+    public const string PRECIOUS_MEMORIES = 'Precious Memories'; // get some items when doing quality time
+    public const string SECOND_STOMACH = 'Second Stomach'; // much larger stomach, but only for favorite foods
+
 }

--- a/api/src/Model/MeritInfo.php
+++ b/api/src/Model/MeritInfo.php
@@ -104,4 +104,10 @@ final class MeritInfo
         // phoenixes
         MeritEnum::ETERNAL,
     ];
+
+    public const array SELF_REFLECTION_MERITS = [
+        MeritEnum::OF_HEART_AND_MIND,
+        MeritEnum::PRECIOUS_MEMORIES,
+        MeritEnum::SECOND_STOMACH,
+    ];
 }

--- a/api/src/Service/PetActivity/EatingService.php
+++ b/api/src/Service/PetActivity/EatingService.php
@@ -138,7 +138,7 @@ class EatingService
             $pet->increaseCaffeine($caffeine);
 
         $pet->increasePsychedelic($food->psychedelic);
-        $pet->increaseFood($food->food, $secondStomachActive);
+        $pet->increaseFood($food->food, null, $secondStomachActive);
 
         if($food->junk > 0)
             $pet->increaseJunk($food->junk, $secondStomachActive);

--- a/api/src/Service/PetActivity/EatingService.php
+++ b/api/src/Service/PetActivity/EatingService.php
@@ -66,14 +66,15 @@ class EatingService
      */
     public function doEat(Pet $pet, FoodWithSpice $food, ?PetActivityLog $activityLog): bool
     {
+        $secondStomach = self::getFavoriteFlavorStrength($pet, $food) > 0;
         // pets will not eat if their stomach is already full
-        if($pet->getJunk() + $pet->getFood() >= $pet->getStomachSize(self::getFavoriteFlavorStrength($pet, $food) > 0))
+        if($pet->getJunk() + $pet->getFood() >= $pet->getStomachSize($secondStomach)) // Second stomach check
             return false;
 
         if($pet->wantsSobriety() && ($food->alcohol || $food->caffeine > 0 || $food->psychedelic > 0))
             return false;
 
-        $this->applyFoodEffects($pet, $food);
+        $this->applyFoodEffects($pet, $food, $secondStomach);
 
         // consider favorite flavor:
         $randomFlavor = $food->randomFlavor > 0 ? $this->rng->rngNextFromArray(FlavorEnum::cases()) : null;
@@ -122,7 +123,7 @@ class EatingService
         return $favoriteFlavorStrength;
     }
 
-    public function applyFoodEffects(Pet $pet, FoodWithSpice $food): void
+    public function applyFoodEffects(Pet $pet, FoodWithSpice $food, bool $secondStomachActive = false): void
     {
         $pet->increaseAlcohol($food->alcohol);
 
@@ -137,10 +138,10 @@ class EatingService
             $pet->increaseCaffeine($caffeine);
 
         $pet->increasePsychedelic($food->psychedelic);
-        $pet->increaseFood($food->food);
+        $pet->increaseFood($food->food, $secondStomachActive);
 
         if($food->junk > 0)
-            $pet->increaseJunk($food->junk);
+            $pet->increaseJunk($food->junk, $secondStomachActive);
         else if($food->junk < 0)
             $pet->increasePoison($food->junk);
 
@@ -281,7 +282,9 @@ class EatingService
 
             $itemName = $food->name;
 
-            if($pet->getJunk() + $pet->getFood() >= $pet->getStomachSize(self::getFavoriteFlavorStrength($pet, $food) > 0)) //Include second stomach if food is fav
+            $secondStomach = self::getFavoriteFlavorStrength($pet, $food) > 0;
+
+            if($pet->getJunk() + $pet->getFood() >= $pet->getStomachSize($secondStomach)) //Include second stomach if food is fav
                 continue;
 
             if($pet->wantsSobriety() && ($food->alcohol > 0 || $food->caffeine > 0 || $food->psychedelic > 0))
@@ -290,7 +293,7 @@ class EatingService
                 continue;
             }
 
-            $this->applyFoodEffects($pet, $food);
+            $this->applyFoodEffects($pet, $food, $secondStomach);
 
             // consider favorite flavor:
             $randomFlavor = $food->randomFlavor > 0 ? $this->rng->rngNextFromArray(FlavorEnum::cases()) : null;

--- a/api/src/Service/PetActivity/EatingService.php
+++ b/api/src/Service/PetActivity/EatingService.php
@@ -67,7 +67,7 @@ class EatingService
     public function doEat(Pet $pet, FoodWithSpice $food, ?PetActivityLog $activityLog): bool
     {
         // pets will not eat if their stomach is already full
-        if($pet->getJunk() + $pet->getFood() >= $pet->getStomachSize())
+        if($pet->getJunk() + $pet->getFood() >= $pet->getStomachSize(self::getFavoriteFlavorStrength($pet, $food) > 0))
             return false;
 
         if($pet->wantsSobriety() && ($food->alcohol || $food->caffeine > 0 || $food->psychedelic > 0))
@@ -281,7 +281,7 @@ class EatingService
 
             $itemName = $food->name;
 
-            if($pet->getJunk() + $pet->getFood() >= $pet->getStomachSize())
+            if($pet->getJunk() + $pet->getFood() >= $pet->getStomachSize(self::getFavoriteFlavorStrength($pet, $food) > 0)) //Include second stomach if food is fav
                 continue;
 
             if($pet->wantsSobriety() && ($food->alcohol > 0 || $food->caffeine > 0 || $food->psychedelic > 0))


### PR DESCRIPTION
## About
<!-- Describe this change as you would to a player who's not familiar with it. -->
Replaces the self-reflection reconciliation choice with a choice of 3 merits, and moves reconciliation to heartessence. If a pet already has all possible self-reflection merits, they instead will go on an adventure in their next pet hours and bring back a heartessence.

- Merits
  - Of Heart and Mind
     - [ ] Bonus experience while love is at 'very loved'
  -  Precious Memories
     - [ ] Pet gains 1 of 3 new status when spending quality time (status duration equal to built up hours)
       - [ ] Memories of Bravery - Pet can't lose safety for the duration.
       - [ ] Memories of Love - Pet has a 1 in 4 chance after bring home an item to also bring home a 'Heartcookie' (Food, delicious, random flavor, snack, good luck chance)
       - [ ] Memories of Joy - Pet is more 'fertile' (Higher chance of pregnancy) & progresses relationships faster for the duration
  - Second Stomach
    - [X] Pets can overeat somewhat (+10 stomach size), if the food they eat has a favorite flavor.
    - [X] Overstuffed label for this effect

- Self-reflection points
  - [ ] Dialog to choose from the merits
  - [ ] Text if you already have all the merits along the lines of 'pet may do something soon'
  - [ ] Adventure to get a heartessence and subtract a point if all reflect merits obtained

- Heartessence
  - [ ] Reconciliation migrated over

- Migrations
  - [ ] Merits
  - [ ] Status Effects & Items
  - [ ] Give all pets that completed the heart dimension stuff to get a point but are under a point, a point! So people don't lose out on that for it not being a feature yet. 

## Why
<!-- Explain why you made this change. What design goals does this hit (see: https://poppyseedpets.com/poppyopedia/designGoal)? How does this interact with the game as a whole? -->

Self-reflection points are kinda...deadish weight right now. They take up space in the status menu for pets with no breakups or disliked pets (especially friend of the world pets), and its not necessarily hard to get at least 1 per pet, so you can have a lot of pets with a point just wasting away. Their only other use (changing guild) is dead.

Making the points instead allow merits selection I think would feel a lot more reward as a player, as it can have more of a lasting impact compared to a single reconciliation, and merits are cool & can have some nice flavor. Moving reconciliation to heartessence instead should make it easier to actually use for pets that need it.

Design Goals Hit:
- Cute & Nerdy - Funny affection themed (sort of) merits!
- Emergent Gameplay & Goal setting - You can get a cool merit for doing the entire heart dimension thing, and collect all 3 if you use your birthday muffins too! If a pet has a lot of break-ups you want to fix you can also use all the heart-essence from doing heart-dimension stuffs!
- Made with Help from Players - Snek

## Notes
<!-- Was there anything notable about the implementation? This can include comments about design choices, problems encountered, any interesting bits noticed in the codebase, limitations, impact this might have on the repo, other ideas that may have been had! Any of these are good -->
