### PR TITLE
Add pets born, active pets, and new pets stats

### DIFF
--- a/api/migrations/2026/05/Version20260510013000.php
+++ b/api/migrations/2026/05/Version20260510013000.php
@@ -21,7 +21,7 @@ final class Version20260510013000 extends AbstractMigration
 {
     public function getDescription(): string
     {
-        return 'Add pets born and total pets stats.';
+        return 'Adds new pets, pets born, active pets stats.';
     }
 
     public function up(Schema $schema): void
@@ -32,11 +32,16 @@ final class Version20260510013000 extends AbstractMigration
         $this->addSql('ALTER TABLE daily_stats ADD COLUMN pets_born_28day INT NULL DEFAULT NULL AFTER pets_born_7day');
         $this->addSql('ALTER TABLE daily_stats ADD COLUMN pets_born_lifetime INT NULL DEFAULT NULL AFTER pets_born_28day');
 
-        $this->addSql('ALTER TABLE daily_stats ADD COLUMN pets_total_1day INT NULL DEFAULT NULL AFTER pets_born_lifetime');
-        $this->addSql('ALTER TABLE daily_stats ADD COLUMN pets_total_3day INT NULL DEFAULT NULL AFTER pets_total_1day');
-        $this->addSql('ALTER TABLE daily_stats ADD COLUMN pets_total_7day INT NULL DEFAULT NULL AFTER pets_total_3day');
-        $this->addSql('ALTER TABLE daily_stats ADD COLUMN pets_total_28day INT NULL DEFAULT NULL AFTER pets_total_7day');
-        $this->addSql('ALTER TABLE daily_stats ADD COLUMN pets_total_lifetime INT NULL DEFAULT NULL AFTER pets_total_28day');
+        $this->addSql('ALTER TABLE daily_stats ADD COLUMN pets_active_1day INT NULL DEFAULT NULL AFTER pets_born_lifetime');
+        $this->addSql('ALTER TABLE daily_stats ADD COLUMN pets_active_3day INT NULL DEFAULT NULL AFTER pets_active_1day');
+        $this->addSql('ALTER TABLE daily_stats ADD COLUMN pets_active_7day INT NULL DEFAULT NULL AFTER pets_active_3day');
+        $this->addSql('ALTER TABLE daily_stats ADD COLUMN pets_active_28day INT NULL DEFAULT NULL AFTER pets_active_7day');
+        $this->addSql('ALTER TABLE daily_stats ADD COLUMN pets_active_lifetime INT NULL DEFAULT NULL AFTER pets_active_28day');
+
+        $this->addSql('ALTER TABLE daily_stats ADD COLUMN new_pets_1day INT NULL DEFAULT NULL AFTER pets_active_lifetime');
+        $this->addSql('ALTER TABLE daily_stats ADD COLUMN new_pets_3day INT NULL DEFAULT NULL AFTER new_pets_1day');
+        $this->addSql('ALTER TABLE daily_stats ADD COLUMN new_pets_7day INT NULL DEFAULT NULL AFTER new_pets_3day');
+        $this->addSql('ALTER TABLE daily_stats ADD COLUMN new_pets_28day INT NULL DEFAULT NULL AFTER new_pets_7day');
     }
 
     public function down(Schema $schema): void

--- a/api/migrations/2026/05/Version20260510013000.php
+++ b/api/migrations/2026/05/Version20260510013000.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the Poppy Seed Pets API.
+ *
+ * The Poppy Seed Pets API is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * The Poppy Seed Pets API is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with The Poppy Seed Pets API. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260510013000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add pets born and total pets stats.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE daily_stats ADD COLUMN pets_born_1day INT NULL DEFAULT NULL AFTER unlocked_portal_lifetime');
+        $this->addSql('ALTER TABLE daily_stats ADD COLUMN pets_born_3day INT NULL DEFAULT NULL AFTER pets_born_1day');
+        $this->addSql('ALTER TABLE daily_stats ADD COLUMN pets_born_7day INT NULL DEFAULT NULL AFTER pets_born_3day');
+        $this->addSql('ALTER TABLE daily_stats ADD COLUMN pets_born_28day INT NULL DEFAULT NULL AFTER pets_born_7day');
+        $this->addSql('ALTER TABLE daily_stats ADD COLUMN pets_born_lifetime INT NULL DEFAULT NULL AFTER pets_born_28day');
+
+        $this->addSql('ALTER TABLE daily_stats ADD COLUMN pets_total_1day INT NULL DEFAULT NULL AFTER pets_born_lifetime');
+        $this->addSql('ALTER TABLE daily_stats ADD COLUMN pets_total_3day INT NULL DEFAULT NULL AFTER pets_total_1day');
+        $this->addSql('ALTER TABLE daily_stats ADD COLUMN pets_total_7day INT NULL DEFAULT NULL AFTER pets_total_3day');
+        $this->addSql('ALTER TABLE daily_stats ADD COLUMN pets_total_28day INT NULL DEFAULT NULL AFTER pets_total_7day');
+        $this->addSql('ALTER TABLE daily_stats ADD COLUMN pets_total_lifetime INT NULL DEFAULT NULL AFTER pets_total_28day');
+    }
+
+    public function down(Schema $schema): void
+    {
+    }
+}

--- a/api/migrations/2026/05/Version20260510013000.php
+++ b/api/migrations/2026/05/Version20260510013000.php
@@ -26,22 +26,22 @@ final class Version20260510013000 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $this->addSql('ALTER TABLE daily_stats ADD COLUMN pets_born_1day INT NULL DEFAULT NULL AFTER unlocked_portal_lifetime');
-        $this->addSql('ALTER TABLE daily_stats ADD COLUMN pets_born_3day INT NULL DEFAULT NULL AFTER pets_born_1day');
-        $this->addSql('ALTER TABLE daily_stats ADD COLUMN pets_born_7day INT NULL DEFAULT NULL AFTER pets_born_3day');
-        $this->addSql('ALTER TABLE daily_stats ADD COLUMN pets_born_28day INT NULL DEFAULT NULL AFTER pets_born_7day');
-        $this->addSql('ALTER TABLE daily_stats ADD COLUMN pets_born_lifetime INT NULL DEFAULT NULL AFTER pets_born_28day');
+        $this->addSql('ALTER TABLE daily_stats ADD COLUMN pets_born_1day INT NOT NULL DEFAULT 0 AFTER unlocked_portal_lifetime');
+        $this->addSql('ALTER TABLE daily_stats ADD COLUMN pets_born_3day INT NOT NULL DEFAULT 0 AFTER pets_born_1day');
+        $this->addSql('ALTER TABLE daily_stats ADD COLUMN pets_born_7day INT NOT NULL DEFAULT 0 AFTER pets_born_3day');
+        $this->addSql('ALTER TABLE daily_stats ADD COLUMN pets_born_28day INT NOT NULL DEFAULT 0 AFTER pets_born_7day');
+        $this->addSql('ALTER TABLE daily_stats ADD COLUMN pets_born_lifetime INT NOT NULL DEFAULT 0 AFTER pets_born_28day');
 
-        $this->addSql('ALTER TABLE daily_stats ADD COLUMN pets_active_1day INT NULL DEFAULT NULL AFTER pets_born_lifetime');
-        $this->addSql('ALTER TABLE daily_stats ADD COLUMN pets_active_3day INT NULL DEFAULT NULL AFTER pets_active_1day');
-        $this->addSql('ALTER TABLE daily_stats ADD COLUMN pets_active_7day INT NULL DEFAULT NULL AFTER pets_active_3day');
-        $this->addSql('ALTER TABLE daily_stats ADD COLUMN pets_active_28day INT NULL DEFAULT NULL AFTER pets_active_7day');
-        $this->addSql('ALTER TABLE daily_stats ADD COLUMN pets_active_lifetime INT NULL DEFAULT NULL AFTER pets_active_28day');
+        $this->addSql('ALTER TABLE daily_stats ADD COLUMN pets_active_1day INT NOT NULL DEFAULT 0 AFTER pets_born_lifetime');
+        $this->addSql('ALTER TABLE daily_stats ADD COLUMN pets_active_3day INT NOT NULL DEFAULT 0 AFTER pets_active_1day');
+        $this->addSql('ALTER TABLE daily_stats ADD COLUMN pets_active_7day INT NOT NULL DEFAULT 0 AFTER pets_active_3day');
+        $this->addSql('ALTER TABLE daily_stats ADD COLUMN pets_active_28day INT NOT NULL DEFAULT 0 AFTER pets_active_7day');
+        $this->addSql('ALTER TABLE daily_stats ADD COLUMN pets_active_lifetime INT NOT NULL DEFAULT 0 AFTER pets_active_28day');
 
-        $this->addSql('ALTER TABLE daily_stats ADD COLUMN new_pets_1day INT NULL DEFAULT NULL AFTER pets_active_lifetime');
-        $this->addSql('ALTER TABLE daily_stats ADD COLUMN new_pets_3day INT NULL DEFAULT NULL AFTER new_pets_1day');
-        $this->addSql('ALTER TABLE daily_stats ADD COLUMN new_pets_7day INT NULL DEFAULT NULL AFTER new_pets_3day');
-        $this->addSql('ALTER TABLE daily_stats ADD COLUMN new_pets_28day INT NULL DEFAULT NULL AFTER new_pets_7day');
+        $this->addSql('ALTER TABLE daily_stats ADD COLUMN new_pets_1day INT NOT NULL DEFAULT 0 AFTER pets_active_lifetime');
+        $this->addSql('ALTER TABLE daily_stats ADD COLUMN new_pets_3day INT NOT NULL DEFAULT 0 AFTER new_pets_1day');
+        $this->addSql('ALTER TABLE daily_stats ADD COLUMN new_pets_7day INT NOT NULL DEFAULT 0 AFTER new_pets_3day');
+        $this->addSql('ALTER TABLE daily_stats ADD COLUMN new_pets_28day INT NOT NULL DEFAULT 0 AFTER new_pets_7day');
     }
 
     public function down(Schema $schema): void

--- a/api/src/Command/CalculateDailyStatsCommand.php
+++ b/api/src/Command/CalculateDailyStatsCommand.php
@@ -169,7 +169,7 @@ class CalculateDailyStatsCommand extends Command
                 SELECT
                     COUNT(pet.id) AS total_pets,
                 FROM pet
-                WHERE pet.birth_date>="' . $firstDate . '"
+                WHERE pet.birth_date<="' . $firstDate . '"
             ')
             ->fetchAssociative()['total_pets']
         ;

--- a/api/src/Command/CalculateDailyStatsCommand.php
+++ b/api/src/Command/CalculateDailyStatsCommand.php
@@ -209,8 +209,7 @@ class CalculateDailyStatsCommand extends Command
                 SELECT
                     COUNT(pet.id) AS total_births,
                 FROM pet
-                WHERE DATE(pet.birth_date)="' . $firstDate . '
-                AND pet.mom_id IS NOT NULL"
+                WHERE pet.mom_id IS NOT NULL"
             ')
             ->fetchAssociative()['total_births']
         ;

--- a/api/src/Command/CalculateDailyStatsCommand.php
+++ b/api/src/Command/CalculateDailyStatsCommand.php
@@ -110,6 +110,18 @@ class CalculateDailyStatsCommand extends Command
             ->setUnlockedPortal7Day($this->getUnlocked(UnlockableFeatureEnum::HollowEarth, $week))
             ->setUnlockedPortal28Day($this->getUnlocked(UnlockableFeatureEnum::HollowEarth, $month))
             ->setUnlockedPortalLifetime($this->getLifetimeUnlocked(UnlockableFeatureEnum::HollowEarth))
+
+            ->setPetsBorn1Day($this->getBornPets($oneDay))
+            ->setPetsBorn3Day($this->getBornPets($threeDay))
+            ->setPetsBorn7Day($this->getBornPets($week))
+            ->setPetsBorn28Day($this->getBornPets($month))
+            ->setPetsBornLifetime($this->getBornPetsLifetime())
+
+            ->setTotalPets1Day($this->getTotalPets($oneDay))
+            ->setTotalPets3Day($this->getTotalPets($threeDay))
+            ->setTotalPets7Day($this->getTotalPets($week))
+            ->setTotalPets28Day($this->getTotalPets($month))
+            ->setTotalPetsLifetime($this->getTotalPetsLifetime())
         ;
 
         $this->em->persist($dailyStats);
@@ -142,11 +154,65 @@ class CalculateDailyStatsCommand extends Command
             ->executeQuery('
                 SELECT
                     COUNT(user.id) AS total_users,
-                    SUM(user.moneys) AS total_moneys
+                    SUM(user.moneys) AS total_moneys,
                 FROM user
                 WHERE user.last_activity>="' . $firstDate . '"
             ')
             ->fetchAssociative()
+        ;
+    }
+
+    public function getTotalPets(string $firstDate): int
+    {
+        return $this->em->getConnection()
+            ->executeQuery('
+                SELECT
+                    COUNT(pet.id) AS total_pets,
+                FROM pet
+                WHERE pet.birth_date>="' . $firstDate . '"
+            ')
+            ->fetchAssociative()['total_pets']
+        ;
+    }
+
+    public function getTotalPetsLifetime(): int
+    {
+        return $this->em->getConnection()
+            ->executeQuery('
+                SELECT
+                    COUNT(pet.id) AS total_pets,
+                FROM pet"
+            ')
+            ->fetchAssociative()['total_pets']
+        ;
+    }
+
+    public function getBornPets(string $firstDate): int
+    {
+        return $this->em->getConnection()
+            ->executeQuery('
+                SELECT
+                    COUNT(pet.id) AS total_births,
+                FROM pet
+                WHERE pet.birth_date>="' . $firstDate . '
+                AND DATE(pet.birth_date)="' . $firstDate . '
+                AND pet.mom_id IS NOT NULL"
+            ')
+            ->fetchAssociative()['total_births']
+        ;
+    }
+
+    public function getBornPetsLifetime(): int
+    {
+        return $this->em->getConnection()
+            ->executeQuery('
+                SELECT
+                    COUNT(pet.id) AS total_births,
+                FROM pet
+                WHERE DATE(pet.birth_date)="' . $firstDate . '
+                AND pet.mom_id IS NOT NULL"
+            ')
+            ->fetchAssociative()['total_births']
         ;
     }
 

--- a/api/src/Command/CalculateDailyStatsCommand.php
+++ b/api/src/Command/CalculateDailyStatsCommand.php
@@ -154,7 +154,7 @@ class CalculateDailyStatsCommand extends Command
             ->executeQuery('
                 SELECT
                     COUNT(user.id) AS total_users,
-                    SUM(user.moneys) AS total_moneys,
+                    SUM(user.moneys) AS total_moneys
                 FROM user
                 WHERE user.last_activity>="' . $firstDate . '"
             ')
@@ -167,7 +167,7 @@ class CalculateDailyStatsCommand extends Command
         return $this->em->getConnection()
             ->executeQuery('
                 SELECT
-                    COUNT(pet.id) AS total_pets,
+                    COUNT(pet.id) AS total_pets
                 FROM pet
                 WHERE pet.birth_date<="' . $firstDate . '"
             ')
@@ -180,7 +180,7 @@ class CalculateDailyStatsCommand extends Command
         return $this->em->getConnection()
             ->executeQuery('
                 SELECT
-                    COUNT(pet.id) AS total_pets,
+                    COUNT(pet.id) AS total_pets
                 FROM pet"
             ')
             ->fetchAssociative()['total_pets']
@@ -192,7 +192,7 @@ class CalculateDailyStatsCommand extends Command
         return $this->em->getConnection()
             ->executeQuery('
                 SELECT
-                    COUNT(pet.id) AS total_births,
+                    COUNT(pet.id) AS total_births
                 FROM pet
                 WHERE pet.birth_date>="' . $firstDate . '
                 AND pet.mom_id IS NOT NULL"
@@ -206,7 +206,7 @@ class CalculateDailyStatsCommand extends Command
         return $this->em->getConnection()
             ->executeQuery('
                 SELECT
-                    COUNT(pet.id) AS total_births,
+                    COUNT(pet.id) AS total_births
                 FROM pet
                 WHERE pet.mom_id IS NOT NULL"
             ')

--- a/api/src/Command/CalculateDailyStatsCommand.php
+++ b/api/src/Command/CalculateDailyStatsCommand.php
@@ -195,7 +195,6 @@ class CalculateDailyStatsCommand extends Command
                     COUNT(pet.id) AS total_births,
                 FROM pet
                 WHERE pet.birth_date>="' . $firstDate . '
-                AND DATE(pet.birth_date)="' . $firstDate . '
                 AND pet.mom_id IS NOT NULL"
             ')
             ->fetchAssociative()['total_births']

--- a/api/src/Command/CalculateDailyStatsCommand.php
+++ b/api/src/Command/CalculateDailyStatsCommand.php
@@ -117,11 +117,16 @@ class CalculateDailyStatsCommand extends Command
             ->setPetsBorn28Day($this->getBornPets($month))
             ->setPetsBornLifetime($this->getBornPetsLifetime())
 
-            ->setTotalPets1Day($this->getTotalPets($oneDay))
-            ->setTotalPets3Day($this->getTotalPets($threeDay))
-            ->setTotalPets7Day($this->getTotalPets($week))
-            ->setTotalPets28Day($this->getTotalPets($month))
-            ->setTotalPetsLifetime($this->getTotalPetsLifetime())
+            ->setNewPets1Day($this->getNewPets($oneDay))
+            ->setNewPets3Day($this->getNewPets($threeDay))
+            ->setNewPets7Day($this->getNewPets($week))
+            ->setNewPets28Day($this->getNewPets($month))
+
+            ->setActivePets1Day($this->getActivepets($oneDay))
+            ->setActivePets3Day($this->getActivepets($threeDay))
+            ->setActivePets7Day($this->getActivepets($week))
+            ->setActivePets28Day($this->getActivepets($month))
+            ->setActivePetsLifetime($this->getActivePetsLifeTime())
         ;
 
         $this->em->persist($dailyStats);
@@ -162,39 +167,39 @@ class CalculateDailyStatsCommand extends Command
         ;
     }
 
-    public function getTotalPets(string $firstDate): int
+    public function getActivePets(string $firstDate): int
     {
-        return $this->em->getConnection()
+        return (int)$this->em->getConnection()
             ->executeQuery('
                 SELECT
-                    COUNT(pet.id) AS total_pets
+                    COUNT(pet.id) AS active_pets
                 FROM pet
-                WHERE pet.birth_date<="' . $firstDate . '"
+                WHERE pet.last_interacted>="' . $firstDate . '"
             ')
-            ->fetchAssociative()['total_pets']
+            ->fetchAssociative()['active_pets']
         ;
     }
 
-    public function getTotalPetsLifetime(): int
+    public function getActivePetsLifetime(): int
     {
-        return $this->em->getConnection()
+        return (int)$this->em->getConnection()
             ->executeQuery('
                 SELECT
-                    COUNT(pet.id) AS total_pets
-                FROM pet"
+                    COUNT(pet.id) AS active_pets
+                FROM pet
             ')
-            ->fetchAssociative()['total_pets']
+            ->fetchAssociative()['active_pets']
         ;
     }
 
     public function getBornPets(string $firstDate): int
     {
-        return $this->em->getConnection()
+        return (int)$this->em->getConnection()
             ->executeQuery('
                 SELECT
                     COUNT(pet.id) AS total_births
                 FROM pet
-                WHERE pet.birth_date>="' . $firstDate . '
+                WHERE pet.birth_date>="' . $firstDate . '"
                 AND pet.mom_id IS NOT NULL"
             ')
             ->fetchAssociative()['total_births']
@@ -203,14 +208,27 @@ class CalculateDailyStatsCommand extends Command
 
     public function getBornPetsLifetime(): int
     {
-        return $this->em->getConnection()
+        return (int)$this->em->getConnection()
             ->executeQuery('
                 SELECT
                     COUNT(pet.id) AS total_births
                 FROM pet
-                WHERE pet.mom_id IS NOT NULL"
+                WHERE pet.mom_id IS NOT NULL
             ')
             ->fetchAssociative()['total_births']
+        ;
+    }
+
+    public function getNewPets(string $firstDate): int
+    {
+        return (int)$this->em->getConnection()
+            ->executeQuery('
+                SELECT
+                    COUNT(pet.id) AS new_pets
+                FROM pet
+                WHERE pet.birth_date>="' . $firstDate . '"
+            ')
+            ->fetchAssociative()['new_pets']
         ;
     }
 

--- a/api/src/Entity/DailyStats.php
+++ b/api/src/Entity/DailyStats.php
@@ -187,11 +187,11 @@ class DailyStats
 
     #[ORM\Column(type: 'integer')]
     #[Groups(['globalStats'])]
-    private int $petsBorn1Day = null;
+    private int $petsBorn1Day = 0;
 
     #[ORM\Column(type: 'integer')]
     #[Groups(['globalStats'])]
-    private int $petsBorn3Day = null;
+    private int $petsBorn3Day = 0;
 
     #[ORM\Column(type: 'integer')]
     #[Groups(['globalStats'])]
@@ -847,7 +847,7 @@ class DailyStats
         return $this->activePets7Day;
     }
 
-    public function setactivePets7Day(?int $activePets7Day): self
+    public function setactivePets7Day(int $activePets7Day): self
     {
         $this->activePets7Day = $activePets7Day;
         return $this;

--- a/api/src/Entity/DailyStats.php
+++ b/api/src/Entity/DailyStats.php
@@ -207,23 +207,39 @@ class DailyStats
 
     #[ORM\Column(type: 'integer', nullable: true)]
     #[Groups(['globalStats'])]
-    private ?int $totalPets1Day = null;
+    private ?int $activePets1Day = null;
 
     #[ORM\Column(type: 'integer', nullable: true)]
     #[Groups(['globalStats'])]
-    private ?int $totalPets3Day = null;
+    private ?int $activePets3Day = null;
 
     #[ORM\Column(type: 'integer', nullable: true)]
     #[Groups(['globalStats'])]
-    private ?int $totalPets7Day = null;
+    private ?int $activePets7Day = null;
 
     #[ORM\Column(type: 'integer', nullable: true)]
     #[Groups(['globalStats'])]
-    private ?int $totalPets28Day = null;
+    private ?int $activePets28Day = null;
 
     #[ORM\Column(type: 'integer', nullable: true)]
     #[Groups(['globalStats'])]
-    private ?int $totalPetsLifetime = null;
+    private ?int $activePetsLifetime = null;
+
+    #[ORM\Column(type: 'integer', nullable: true)]
+    #[Groups(['globalStats'])]
+    private ?int $newPets1Day = null;
+
+    #[ORM\Column(type: 'integer', nullable: true)]
+    #[Groups(['globalStats'])]
+    private ?int $newPets3Day = null;
+
+    #[ORM\Column(type: 'integer', nullable: true)]
+    #[Groups(['globalStats'])]
+    private ?int $newPets7Day = null;
+
+    #[ORM\Column(type: 'integer', nullable: true)]
+    #[Groups(['globalStats'])]
+    private ?int $newPets28Day = null;
 
     public function getId(): int
     {
@@ -822,70 +838,126 @@ class DailyStats
     /**
      * @return int|null
      */
-    public function getTotalPets1Day(): ?int
+    public function getactivePets1Day(): ?int
     {
-        return $this->totalPets1Day;
+        return $this->activePets1Day;
     }
 
-    public function setTotalPets1Day(?int $totalPets1Day): self
+    public function setactivePets1Day(?int $activePets1Day): self
     {
-        $this->totalPets1Day = $totalPets1Day;
+        $this->activePets1Day = $activePets1Day;
         return $this;
     }
 
     /**
      * @return int|null
      */
-    public function getTotalPets3Day(): ?int
+    public function getactivePets3Day(): ?int
     {
-        return $this->totalPets3Day;
+        return $this->activePets3Day;
     }
 
-    public function setTotalPets3Day(?int $totalPets3Day): self
+    public function setactivePets3Day(?int $activePets3Day): self
     {
-        $this->totalPets3Day = $totalPets3Day;
+        $this->activePets3Day = $activePets3Day;
         return $this;
     }
 
     /**
      * @return int|null
      */
-    public function getTotalPets7Day(): ?int
+    public function getactivePets7Day(): ?int
     {
-        return $this->totalPets7Day;
+        return $this->activePets7Day;
     }
 
-    public function setTotalPets7Day(?int $totalPets7Day): self
+    public function setactivePets7Day(?int $activePets7Day): self
     {
-        $this->totalPets7Day = $totalPets7Day;
+        $this->activePets7Day = $activePets7Day;
         return $this;
     }
 
     /**
      * @return int|null
      */
-    public function getTotalPets28Day(): ?int
+    public function getactivePets28Day(): ?int
     {
-        return $this->totalPets28Day;
+        return $this->activePets28Day;
     }
 
-    public function setTotalPets28Day(?int $totalPets28Day): self
+    public function setactivePets28Day(?int $activePets28Day): self
     {
-        $this->totalPets28Day = $totalPets28Day;
+        $this->activePets28Day = $activePets28Day;
         return $this;
     }
 
     /**
      * @return int|null
      */
-    public function getTotalPetsLifetime(): ?int
+    public function getactivePetsLifetime(): ?int
     {
-        return $this->totalPetsLifetime;
+        return $this->activePetsLifetime;
     }
 
-    public function setTotalPetsLifetime(?int $totalPetsLifetime): self
+    public function setactivePetsLifetime(?int $activePetsLifetime): self
     {
-        $this->totalPetsLifetime = $totalPetsLifetime;
+        $this->activePetsLifetime = $activePetsLifetime;
+        return $this;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getnewPets1Day(): ?int
+    {
+        return $this->newPets1Day;
+    }
+
+    public function setnewPets1Day(?int $newPets1Day): self
+    {
+        $this->newPets1Day = $newPets1Day;
+        return $this;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getnewPets3Day(): ?int
+    {
+        return $this->newPets3Day;
+    }
+
+    public function setnewPets3Day(?int $newPets3Day): self
+    {
+        $this->newPets3Day = $newPets3Day;
+        return $this;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getnewPets7Day(): ?int
+    {
+        return $this->newPets7Day;
+    }
+
+    public function setnewPets7Day(?int $newPets7Day): self
+    {
+        $this->newPets7Day = $newPets7Day;
+        return $this;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getnewPets28Day(): ?int
+    {
+        return $this->newPets28Day;
+    }
+
+    public function setnewPets28Day(?int $newPets28Day): self
+    {
+        $this->newPets28Day = $newPets28Day;
         return $this;
     }
 }

--- a/api/src/Entity/DailyStats.php
+++ b/api/src/Entity/DailyStats.php
@@ -185,61 +185,61 @@ class DailyStats
     #[Groups(['globalStats'])]
     private ?int $unlockedPortalLifetime = null;
 
-    #[ORM\Column(type: 'integer', nullable: true)]
+    #[ORM\Column(type: 'integer')]
     #[Groups(['globalStats'])]
-    private ?int $petsBorn1Day = null;
+    private int $petsBorn1Day = null;
 
-    #[ORM\Column(type: 'integer', nullable: true)]
+    #[ORM\Column(type: 'integer')]
     #[Groups(['globalStats'])]
-    private ?int $petsBorn3Day = null;
+    private int $petsBorn3Day = null;
 
-    #[ORM\Column(type: 'integer', nullable: true)]
+    #[ORM\Column(type: 'integer')]
     #[Groups(['globalStats'])]
-    private ?int $petsBorn7Day = null;
+    private int $petsBorn7Day = 0;
 
-    #[ORM\Column(type: 'integer', nullable: true)]
+    #[ORM\Column(type: 'integer')]
     #[Groups(['globalStats'])]
-    private ?int $petsBorn28Day = null;
+    private int $petsBorn28Day = 0;
 
-    #[ORM\Column(type: 'integer', nullable: true)]
+    #[ORM\Column(type: 'integer')]
     #[Groups(['globalStats'])]
-    private ?int $petsBornLifetime = null;
+    private int $petsBornLifetime = 0;
 
-    #[ORM\Column(type: 'integer', nullable: true)]
+    #[ORM\Column(type: 'integer')]
     #[Groups(['globalStats'])]
-    private ?int $activePets1Day = null;
+    private int $activePets1Day = 0;
 
-    #[ORM\Column(type: 'integer', nullable: true)]
+    #[ORM\Column(type: 'integer')]
     #[Groups(['globalStats'])]
-    private ?int $activePets3Day = null;
+    private int $activePets3Day = 0;
 
-    #[ORM\Column(type: 'integer', nullable: true)]
+    #[ORM\Column(type: 'integer')]
     #[Groups(['globalStats'])]
-    private ?int $activePets7Day = null;
+    private int $activePets7Day = 0;
 
-    #[ORM\Column(type: 'integer', nullable: true)]
+    #[ORM\Column(type: 'integer')]
     #[Groups(['globalStats'])]
-    private ?int $activePets28Day = null;
+    private int $activePets28Day = 0;
 
-    #[ORM\Column(type: 'integer', nullable: true)]
+    #[ORM\Column(type: 'integer')]
     #[Groups(['globalStats'])]
-    private ?int $activePetsLifetime = null;
+    private int $activePetsLifetime = 0;
 
-    #[ORM\Column(type: 'integer', nullable: true)]
+    #[ORM\Column(type: 'integer')]
     #[Groups(['globalStats'])]
-    private ?int $newPets1Day = null;
+    private int $newPets1Day = 0;
 
-    #[ORM\Column(type: 'integer', nullable: true)]
+    #[ORM\Column(type: 'integer')]
     #[Groups(['globalStats'])]
-    private ?int $newPets3Day = null;
+    private int $newPets3Day = 0;
 
-    #[ORM\Column(type: 'integer', nullable: true)]
+    #[ORM\Column(type: 'integer')]
     #[Groups(['globalStats'])]
-    private ?int $newPets7Day = null;
+    private int $newPets7Day = 0;
 
-    #[ORM\Column(type: 'integer', nullable: true)]
+    #[ORM\Column(type: 'integer')]
     #[Groups(['globalStats'])]
-    private ?int $newPets28Day = null;
+    private int $newPets28Day = 0;
 
     public function getId(): int
     {
@@ -765,108 +765,84 @@ class DailyStats
         return $this;
     }
 
-    /**
-     * @return int|null
-     */
-    public function getPetsBorn1Day(): ?int
+    public function getPetsBorn1Day(): int
     {
         return $this->petsBorn1Day;
     }
 
-    public function setPetsBorn1Day(?int $petsBorn1Day): self
+    public function setPetsBorn1Day(int $petsBorn1Day): self
     {
         $this->petsBorn1Day = $petsBorn1Day;
         return $this;
     }
 
-    /**
-     * @return int|null
-     */
-    public function getPetsBorn3Day(): ?int
+    public function getPetsBorn3Day(): int
     {
         return $this->petsBorn3Day;
     }
 
-    public function setPetsBorn3Day(?int $petsBorn3Day): self
+    public function setPetsBorn3Day(int $petsBorn3Day): self
     {
         $this->petsBorn3Day = $petsBorn3Day;
         return $this;
     }
 
-    /**
-     * @return int|null
-     */
-    public function getPetsBorn7Day(): ?int
+    public function getPetsBorn7Day(): int
     {
         return $this->petsBorn7Day;
     }
 
-    public function setPetsBorn7Day(?int $petsBorn7Day): self
+    public function setPetsBorn7Day(int $petsBorn7Day): self
     {
         $this->petsBorn7Day = $petsBorn7Day;
         return $this;
     }
 
-    /**
-     * @return int|null
-     */
-    public function getPetsBorn28Day(): ?int
+    public function getPetsBorn28Day(): int
     {
         return $this->petsBorn28Day;
     }
 
-    public function setPetsBorn28Day(?int $petsBorn28Day): self
+    public function setPetsBorn28Day(int $petsBorn28Day): self
     {
         $this->petsBorn28Day = $petsBorn28Day;
         return $this;
     }
 
-    /**
-     * @return int|null
-     */
-    public function getPetsBornLifetime(): ?int
+    public function getPetsBornLifetime(): int
     {
         return $this->petsBornLifetime;
     }
 
-    public function setPetsBornLifetime(?int $petsBornLifetime): self
+    public function setPetsBornLifetime(int $petsBornLifetime): self
     {
         $this->petsBornLifetime = $petsBornLifetime;
         return $this;
     }
 
-    /**
-     * @return int|null
-     */
-    public function getactivePets1Day(): ?int
+    public function getactivePets1Day(): int
     {
         return $this->activePets1Day;
     }
 
-    public function setactivePets1Day(?int $activePets1Day): self
+    public function setactivePets1Day(int $activePets1Day): self
     {
         $this->activePets1Day = $activePets1Day;
         return $this;
     }
 
-    /**
-     * @return int|null
-     */
-    public function getactivePets3Day(): ?int
+    public function getactivePets3Day(): int
     {
         return $this->activePets3Day;
     }
 
-    public function setactivePets3Day(?int $activePets3Day): self
+    public function setactivePets3Day(int $activePets3Day): self
     {
         $this->activePets3Day = $activePets3Day;
         return $this;
     }
 
-    /**
-     * @return int|null
-     */
-    public function getactivePets7Day(): ?int
+    public function getactivePets7Day(): int
     {
         return $this->activePets7Day;
     }
@@ -877,85 +853,67 @@ class DailyStats
         return $this;
     }
 
-    /**
-     * @return int|null
-     */
-    public function getactivePets28Day(): ?int
+    public function getactivePets28Day(): int
     {
         return $this->activePets28Day;
     }
 
-    public function setactivePets28Day(?int $activePets28Day): self
+    public function setactivePets28Day(int $activePets28Day): self
     {
         $this->activePets28Day = $activePets28Day;
         return $this;
     }
 
-    /**
-     * @return int|null
-     */
-    public function getactivePetsLifetime(): ?int
+    public function getactivePetsLifetime(): int
     {
         return $this->activePetsLifetime;
     }
 
-    public function setactivePetsLifetime(?int $activePetsLifetime): self
+    public function setactivePetsLifetime(int $activePetsLifetime): self
     {
         $this->activePetsLifetime = $activePetsLifetime;
         return $this;
     }
 
-    /**
-     * @return int|null
-     */
-    public function getnewPets1Day(): ?int
+    public function getnewPets1Day(): int
     {
         return $this->newPets1Day;
     }
 
-    public function setnewPets1Day(?int $newPets1Day): self
+    public function setnewPets1Day(int $newPets1Day): self
     {
         $this->newPets1Day = $newPets1Day;
         return $this;
     }
 
-    /**
-     * @return int|null
-     */
-    public function getnewPets3Day(): ?int
+    public function getnewPets3Day(): int
     {
         return $this->newPets3Day;
     }
 
-    public function setnewPets3Day(?int $newPets3Day): self
+    public function setnewPets3Day(int $newPets3Day): self
     {
         $this->newPets3Day = $newPets3Day;
         return $this;
     }
 
-    /**
-     * @return int|null
-     */
-    public function getnewPets7Day(): ?int
+    public function getnewPets7Day(): int
     {
         return $this->newPets7Day;
     }
 
-    public function setnewPets7Day(?int $newPets7Day): self
+    public function setnewPets7Day(int $newPets7Day): self
     {
         $this->newPets7Day = $newPets7Day;
         return $this;
     }
 
-    /**
-     * @return int|null
-     */
-    public function getnewPets28Day(): ?int
+    public function getnewPets28Day(): int
     {
         return $this->newPets28Day;
     }
 
-    public function setnewPets28Day(?int $newPets28Day): self
+    public function setnewPets28Day(int $newPets28Day): self
     {
         $this->newPets28Day = $newPets28Day;
         return $this;

--- a/api/src/Entity/DailyStats.php
+++ b/api/src/Entity/DailyStats.php
@@ -185,6 +185,46 @@ class DailyStats
     #[Groups(['globalStats'])]
     private ?int $unlockedPortalLifetime = null;
 
+    #[ORM\Column(type: 'integer', nullable: true)]
+    #[Groups(['globalStats'])]
+    private ?int $petsBorn1Day = null;
+
+    #[ORM\Column(type: 'integer', nullable: true)]
+    #[Groups(['globalStats'])]
+    private ?int $petsBorn3Day = null;
+
+    #[ORM\Column(type: 'integer', nullable: true)]
+    #[Groups(['globalStats'])]
+    private ?int $petsBorn7Day = null;
+
+    #[ORM\Column(type: 'integer', nullable: true)]
+    #[Groups(['globalStats'])]
+    private ?int $petsBorn28Day = null;
+
+    #[ORM\Column(type: 'integer', nullable: true)]
+    #[Groups(['globalStats'])]
+    private ?int $petsBornLifetime = null;
+
+    #[ORM\Column(type: 'integer', nullable: true)]
+    #[Groups(['globalStats'])]
+    private ?int $totalPets1Day = null;
+
+    #[ORM\Column(type: 'integer', nullable: true)]
+    #[Groups(['globalStats'])]
+    private ?int $totalPets3Day = null;
+
+    #[ORM\Column(type: 'integer', nullable: true)]
+    #[Groups(['globalStats'])]
+    private ?int $totalPets7Day = null;
+
+    #[ORM\Column(type: 'integer', nullable: true)]
+    #[Groups(['globalStats'])]
+    private ?int $totalPets28Day = null;
+
+    #[ORM\Column(type: 'integer', nullable: true)]
+    #[Groups(['globalStats'])]
+    private ?int $totalPetsLifetime = null;
+
     public function getId(): int
     {
         return $this->id ?? throw new \LogicException('This entity has not been persisted.');
@@ -706,6 +746,146 @@ class DailyStats
     public function setUnlockedPortalLifetime(?int $unlockedPortalLifetime): self
     {
         $this->unlockedPortalLifetime = $unlockedPortalLifetime;
+        return $this;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getPetsBorn1Day(): ?int
+    {
+        return $this->petsBorn1Day;
+    }
+
+    public function setPetsBorn1Day(?int $petsBorn1Day): self
+    {
+        $this->petsBorn1Day = $petsBorn1Day;
+        return $this;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getPetsBorn3Day(): ?int
+    {
+        return $this->petsBorn3Day;
+    }
+
+    public function setPetsBorn3Day(?int $petsBorn3Day): self
+    {
+        $this->petsBorn3Day = $petsBorn3Day;
+        return $this;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getPetsBorn7Day(): ?int
+    {
+        return $this->petsBorn7Day;
+    }
+
+    public function setPetsBorn7Day(?int $petsBorn7Day): self
+    {
+        $this->petsBorn7Day = $petsBorn7Day;
+        return $this;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getPetsBorn28Day(): ?int
+    {
+        return $this->petsBorn28Day;
+    }
+
+    public function setPetsBorn28Day(?int $petsBorn28Day): self
+    {
+        $this->petsBorn28Day = $petsBorn28Day;
+        return $this;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getPetsBornLifetime(): ?int
+    {
+        return $this->petsBornLifetime;
+    }
+
+    public function setPetsBornLifetime(?int $petsBornLifetime): self
+    {
+        $this->petsBornLifetime = $petsBornLifetime;
+        return $this;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getTotalPets1Day(): ?int
+    {
+        return $this->totalPets1Day;
+    }
+
+    public function setTotalPets1Day(?int $totalPets1Day): self
+    {
+        $this->totalPets1Day = $totalPets1Day;
+        return $this;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getTotalPets3Day(): ?int
+    {
+        return $this->totalPets3Day;
+    }
+
+    public function setTotalPets3Day(?int $totalPets3Day): self
+    {
+        $this->totalPets3Day = $totalPets3Day;
+        return $this;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getTotalPets7Day(): ?int
+    {
+        return $this->totalPets7Day;
+    }
+
+    public function setTotalPets7Day(?int $totalPets7Day): self
+    {
+        $this->totalPets7Day = $totalPets7Day;
+        return $this;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getTotalPets28Day(): ?int
+    {
+        return $this->totalPets28Day;
+    }
+
+    public function setTotalPets28Day(?int $totalPets28Day): self
+    {
+        $this->totalPets28Day = $totalPets28Day;
+        return $this;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getTotalPetsLifetime(): ?int
+    {
+        return $this->totalPetsLifetime;
+    }
+
+    public function setTotalPetsLifetime(?int $totalPetsLifetime): self
+    {
+        $this->totalPetsLifetime = $totalPetsLifetime;
         return $this;
     }
 }

--- a/webapp/src/app/model/global-stats.model.ts
+++ b/webapp/src/app/model/global-stats.model.ts
@@ -63,9 +63,9 @@ export interface GlobalStatsMetric {
 export const GLOBAL_STATS_METRICS: GlobalStatsMetric[] = [
   { label: 'New Players', value: 'newPlayers' },
   { label: 'Active Players', value: 'numberOfPlayers' },
-  { label: 'New Pets', value: 'totalPets' },
+  { label: 'New Pets', value: 'newPets' },
   { label: 'Pets Birthed', value: 'petsBorn' },
-  { label: 'Active Pets', value: 'petsActive' },
+  { label: 'Active Pets', value: 'activePets' },
   { label: 'Total Moneys', value: 'totalMoneys' },
   { label: 'Have Trader', value: 'unlockedTrader' },
   { label: 'Have Fireplace', value: 'unlockedFireplace' },

--- a/webapp/src/app/model/global-stats.model.ts
+++ b/webapp/src/app/model/global-stats.model.ts
@@ -45,10 +45,14 @@ export interface GlobalStatsTimeSeriesModel {
   petsBorn3Day: number;
   petsBorn7Day: number;
   petsBorn28Day: number;
-  totalPets1Day: number;
-  totalPets3Day: number;
-  totalPets7Day: number;
-  totalPets28Day: number;
+  activePets1Day: number;
+  activePets3Day: number;
+  activePets7Day: number;
+  activePets28Day: number;
+  newPets1Day: number;
+  newPets3Day: number;
+  newPets7Day: number;
+  newPets28Day: number;
 }
 
 export interface GlobalStatsMetric {
@@ -59,14 +63,15 @@ export interface GlobalStatsMetric {
 export const GLOBAL_STATS_METRICS: GlobalStatsMetric[] = [
   { label: 'New Players', value: 'newPlayers' },
   { label: 'Active Players', value: 'numberOfPlayers' },
+  { label: 'New Pets', value: 'totalPets' },
+  { label: 'Pets Birthed', value: 'petsBorn' },
+  { label: 'Active Pets', value: 'petsActive' },
   { label: 'Total Moneys', value: 'totalMoneys' },
   { label: 'Have Trader', value: 'unlockedTrader' },
   { label: 'Have Fireplace', value: 'unlockedFireplace' },
   { label: 'Have Greenhouse', value: 'unlockedGreenhouse' },
   { label: 'Have Beehive', value: 'unlockedBeehive' },
-  { label: 'Have Hollow Earth', value: 'unlockedPortal' },
-  { label: 'Total Pets', value: 'totalPets' },
-  { label: 'Pets Born', value: 'petsBorn' }
+  { label: 'Have Hollow Earth', value: 'unlockedPortal' }
 ];
 
 export const GLOBAL_STATS_PERIODS: { label: string; value: string }[] = [

--- a/webapp/src/app/model/global-stats.model.ts
+++ b/webapp/src/app/model/global-stats.model.ts
@@ -41,6 +41,14 @@ export interface GlobalStatsTimeSeriesModel {
   unlockedPortal3Day: number;
   unlockedPortal7Day: number;
   unlockedPortal28Day: number;
+  petsBorn1Day: number;
+  petsBorn3Day: number;
+  petsBorn7Day: number;
+  petsBorn28Day: number;
+  totalPets1Day: number;
+  totalPets3Day: number;
+  totalPets7Day: number;
+  totalPets28Day: number;
 }
 
 export interface GlobalStatsMetric {
@@ -56,7 +64,9 @@ export const GLOBAL_STATS_METRICS: GlobalStatsMetric[] = [
   { label: 'Have Fireplace', value: 'unlockedFireplace' },
   { label: 'Have Greenhouse', value: 'unlockedGreenhouse' },
   { label: 'Have Beehive', value: 'unlockedBeehive' },
-  { label: 'Have Hollow Earth', value: 'unlockedPortal' }
+  { label: 'Have Hollow Earth', value: 'unlockedPortal' },
+  { label: 'Total Pets', value: 'totalPets' },
+  { label: 'Pets Born', value: 'petsBorn' }
 ];
 
 export const GLOBAL_STATS_PERIODS: { label: string; value: string }[] = [


### PR DESCRIPTION
## About
<!-- Describe this change as you would to a player who's not familiar with it. -->
Adds pets born, new pets, and active pets as stats to track.

## Why
<!-- Explain why you made this change. What design goals does this hit (see: https://poppyseedpets.com/poppyopedia/designGoal)? How does this interact with the game as a whole? -->
Cute & Nerdy mostly, I like looking at stats, I think these are cool stats.

## Notes
Also I had to modify the serialization group since uh, yeah global stats are that. dang.

note: removing total pets as a stat I added in favor of new pets and active pets, cooler.