### PR TITLE
Eiri Persona rebalance only

### DIFF
--- a/api/src/Controller/MonsterOfTheWeek/MonsterOfTheWeekHelpers.php
+++ b/api/src/Controller/MonsterOfTheWeek/MonsterOfTheWeekHelpers.php
@@ -266,7 +266,7 @@ final class MonsterOfTheWeekHelpers
         {
             $effects = $item->getTool();
 
-            $points = max($points, $effects->getScience() + ($effects->getFocusSkill() == PetSkillEnum::Science ? 2 : 0) + ($effects->getPreventsBugs() ? 1 : 0));
+            $points = max($points, $effects->getScience() + ($effects->getFocusSkill() == PetSkillEnum::Science ? 2 : 0) + ($effects->getPreventsBugs() ? 1 : 0) + $effects->getHacking() + $effects->getElectronics());
         }
 
         if($item->getEnchants() && $item->getEnchants()->getEffects())


### PR DESCRIPTION
## About
Edits the Eiri Persona food values so that hacking and electronics also add to food value 

## Why
the description claims that it likes 'anything computer-ish or science-y', but right now it strictly includes tools with a science bonus, and a limited number of hard-coded items.

## Notes
If this is too OP, I think electronics could go, but hacking especially seems to strictly fit within the parameters (there are very few hacking tools but a lot of them were severely nerfed for the persona when their bonuses were split up; there aren't a ton of high science tools). If it's not strong enough, I didn't add physics bonus tools even though they're also science-y...