### PR TITLE
Infinity wrangler badge fix

### DIFF
--- a/api/src/Service/PetActivity/Crafting/ProgrammingService.php
+++ b/api/src/Service/PetActivity/Crafting/ProgrammingService.php
@@ -568,20 +568,20 @@ class ProgrammingService implements IPetActivity
         if($pet->getSpecies()->getName() === PetSpeciesName::InfinityImp->value)
             return $this->infinityImpCollectsBlueprint($pet, $actionInterrupted);
 
-        $impDiscovery = '%pet:' . $pet->getId() . '.name% started ' . $actionInterrupted . ', but an Infinity Imp popped up, and started to attack!';
-
-        $this->fieldGuideService->maybeUnlock($pet->getOwner(), 'Infinity Imp', $impDiscovery);
-
-        $activityLog = $this->resolveImpFightOutcome($petWithSkills, $impDiscovery);
+        $activityLog = $this->resolveImpFightOutcome($petWithSkills, $actionInterrupted);
 
         PetBadgeHelpers::awardBadge($this->em, $pet, PetBadgeEnum::WrangledWithInfinities, $activityLog);
 
         return $activityLog;
     }
 
-    private function resolveImpFightOutcome(ComputedPetSkills $petWithSkills, string $impDiscovery): PetActivityLog
+    private function resolveImpFightOutcome(ComputedPetSkills $petWithSkills, string $actionInterrupted): PetActivityLog
     {
         $pet = $petWithSkills->getPet();
+
+        $impDiscovery = '%pet:' . $pet->getId() . '.name% started ' . $actionInterrupted . ', but an Infinity Imp popped up, and started to attack!';
+
+        $this->fieldGuideService->maybeUnlock($pet->getOwner(), 'Infinity Imp', $impDiscovery);
 
         $scienceRoll = $this->rng->rngSkillRoll($petWithSkills->getIntelligence()->getTotal() + $petWithSkills->getScience()->getTotal() + $petWithSkills->getHackingBonus()->getTotal());
         $brawlRoll = $this->rng->rngSkillRoll($petWithSkills->getDexterity()->getTotal() + $petWithSkills->getBrawl()->getTotal());

--- a/api/src/Service/PetActivity/Crafting/ProgrammingService.php
+++ b/api/src/Service/PetActivity/Crafting/ProgrammingService.php
@@ -579,7 +579,6 @@ class ProgrammingService implements IPetActivity
         $impDiscovery = '%pet:' . $pet->getId() . '.name% started ' . $actionInterrupted . ', but an Infinity Imp popped up, and started to attack!';
 
         $this->fieldGuideService->maybeUnlock($pet->getOwner(), 'Infinity Imp', $impDiscovery);
-        PetBadgeHelpers::awardBadge($this->em, $pet, PetBadgeEnum::WrangledWithInfinities, $activityLog);
 
 
         $isLucky = $this->rng->rngNextInt(1, 50) == 1 && $pet->hasMerit(MeritEnum::LUCKY);
@@ -599,7 +598,7 @@ class ProgrammingService implements IPetActivity
                     ->appendEntry('(Lucky~!)')
                     ->addTags(PetActivityLogTagHelpers::findByNames($this->em, [ 'Lucky~!' ]));
             }
-
+            PetBadgeHelpers::awardBadge($this->em, $pet, PetBadgeEnum::WrangledWithInfinities, $activityLog);
             $this->petExperienceService->gainExp($pet, 5, [ PetSkillEnum::Science, PetSkillEnum::Brawl ], $activityLog);
 
             $this->createInfinityImp($pet);
@@ -615,6 +614,7 @@ class ProgrammingService implements IPetActivity
                     ->setIcon('icons/activity-logs/confused')
                     ->addTags(PetActivityLogTagHelpers::findByNames($this->em, [ 'Programming', PetActivityLogTagEnum::Physics ]))
                 ;
+                PetBadgeHelpers::awardBadge($this->em, $pet, PetBadgeEnum::WrangledWithInfinities, $activityLog);
                 $this->petExperienceService->gainExp($pet, 3, [ PetSkillEnum::Science ], $activityLog);
                 $this->inventoryService->petCollectsItem($loot, $pet, $pet->getName() . ' received this by unraveling an Infinity Imp.', $activityLog);
                 return $activityLog;
@@ -629,6 +629,7 @@ class ProgrammingService implements IPetActivity
                     ->setIcon('icons/activity-logs/confused')
                     ->addTags(PetActivityLogTagHelpers::findByNames($this->em, [ 'Programming', 'Fighting' ]))
                 ;
+                PetBadgeHelpers::awardBadge($this->em, $pet, PetBadgeEnum::WrangledWithInfinities, $activityLog);
                 $this->petExperienceService->gainExp($pet, 3, [ PetSkillEnum::Science ], $activityLog);
                 $this->inventoryService->petCollectsItem($loot, $pet, $pet->getName() . ' received this by slaying an Infinity Imp.', $activityLog);
                 return $activityLog;
@@ -638,7 +639,8 @@ class ProgrammingService implements IPetActivity
         $activityLog = PetActivityLogFactory::createUnreadLog($this->em, $pet, $impDiscovery . ' %pet:' . $pet->getId() . '.name% ran away until the imp finally gave up and returned to the strange dimension from whence it came.')
             ->setIcon('icons/activity-logs/confused')
         ;
-
+        
+        PetBadgeHelpers::awardBadge($this->em, $pet, PetBadgeEnum::WrangledWithInfinities, $activityLog);
         
         $this->petExperienceService->gainExp($pet, 2, [ PetSkillEnum::Science ], $activityLog);
         $this->petExperienceService->spendTime($pet, $this->rng->rngNextInt(45, 60), PetActivityStatEnum::PROGRAM, false);

--- a/api/src/Service/PetActivity/Crafting/ProgrammingService.php
+++ b/api/src/Service/PetActivity/Crafting/ProgrammingService.php
@@ -568,6 +568,21 @@ class ProgrammingService implements IPetActivity
         if($pet->getSpecies()->getName() === PetSpeciesName::InfinityImp->value)
             return $this->infinityImpCollectsBlueprint($pet, $actionInterrupted);
 
+        $impDiscovery = '%pet:' . $pet->getId() . '.name% started ' . $actionInterrupted . ', but an Infinity Imp popped up, and started to attack!';
+
+        $this->fieldGuideService->maybeUnlock($pet->getOwner(), 'Infinity Imp', $impDiscovery);
+
+        $activityLog = $this->resolveImpFightOutcome($petWithSkills, $impDiscovery);
+
+        PetBadgeHelpers::awardBadge($this->em, $pet, PetBadgeEnum::WrangledWithInfinities, $activityLog);
+
+        return $activityLog;
+    }
+
+    private function resolveImpFightOutcome(ComputedPetSkills $petWithSkills, string $impDiscovery): PetActivityLog
+    {
+        $pet = $petWithSkills->getPet();
+
         $scienceRoll = $this->rng->rngSkillRoll($petWithSkills->getIntelligence()->getTotal() + $petWithSkills->getScience()->getTotal() + $petWithSkills->getHackingBonus()->getTotal());
         $brawlRoll = $this->rng->rngSkillRoll($petWithSkills->getDexterity()->getTotal() + $petWithSkills->getBrawl()->getTotal());
 
@@ -575,11 +590,6 @@ class ProgrammingService implements IPetActivity
             'Quintessence',
             'Pointer',
         ]);
-
-        $impDiscovery = '%pet:' . $pet->getId() . '.name% started ' . $actionInterrupted . ', but an Infinity Imp popped up, and started to attack!';
-
-        $this->fieldGuideService->maybeUnlock($pet->getOwner(), 'Infinity Imp', $impDiscovery);
-
 
         $isLucky = $this->rng->rngNextInt(1, 50) == 1 && $pet->hasMerit(MeritEnum::LUCKY);
 
@@ -598,50 +608,42 @@ class ProgrammingService implements IPetActivity
                     ->appendEntry('(Lucky~!)')
                     ->addTags(PetActivityLogTagHelpers::findByNames($this->em, [ 'Lucky~!' ]));
             }
-            PetBadgeHelpers::awardBadge($this->em, $pet, PetBadgeEnum::WrangledWithInfinities, $activityLog);
+
             $this->petExperienceService->gainExp($pet, 5, [ PetSkillEnum::Science, PetSkillEnum::Brawl ], $activityLog);
 
             $this->createInfinityImp($pet);
 
             return $activityLog;
         }
-        else if($scienceRoll >= $brawlRoll)
+
+        if($scienceRoll >= $brawlRoll && $scienceRoll >= 20)
         {
-            if($scienceRoll >= 20)
-            {
-                $this->petExperienceService->spendTime($pet, $this->rng->rngNextInt(45, 60), PetActivityStatEnum::PROGRAM, false);
-                $activityLog = PetActivityLogFactory::createUnreadLog($this->em, $pet, $impDiscovery . ' During the fight, %pet:' . $pet->getId() . '.name% exploited a divergence in the imp\'s construction, and unraveled it, receiving ' . $loot . '!')
-                    ->setIcon('icons/activity-logs/confused')
-                    ->addTags(PetActivityLogTagHelpers::findByNames($this->em, [ 'Programming', PetActivityLogTagEnum::Physics ]))
-                ;
-                PetBadgeHelpers::awardBadge($this->em, $pet, PetBadgeEnum::WrangledWithInfinities, $activityLog);
-                $this->petExperienceService->gainExp($pet, 3, [ PetSkillEnum::Science ], $activityLog);
-                $this->inventoryService->petCollectsItem($loot, $pet, $pet->getName() . ' received this by unraveling an Infinity Imp.', $activityLog);
-                return $activityLog;
-            }
+            $this->petExperienceService->spendTime($pet, $this->rng->rngNextInt(45, 60), PetActivityStatEnum::PROGRAM, false);
+            $activityLog = PetActivityLogFactory::createUnreadLog($this->em, $pet, $impDiscovery . ' During the fight, %pet:' . $pet->getId() . '.name% exploited a divergence in the imp\'s construction, and unraveled it, receiving ' . $loot . '!')
+                ->setIcon('icons/activity-logs/confused')
+                ->addTags(PetActivityLogTagHelpers::findByNames($this->em, [ 'Programming', PetActivityLogTagEnum::Physics ]))
+            ;
+            $this->petExperienceService->gainExp($pet, 3, [ PetSkillEnum::Science ], $activityLog);
+            $this->inventoryService->petCollectsItem($loot, $pet, $pet->getName() . ' received this by unraveling an Infinity Imp.', $activityLog);
+            return $activityLog;
         }
-        else
+
+        if($brawlRoll > $scienceRoll && $brawlRoll >= 20)
         {
-            if($brawlRoll >= 20)
-            {
-                $this->petExperienceService->spendTime($pet, $this->rng->rngNextInt(45, 60), PetActivityStatEnum::PROGRAM, false);
-                $activityLog = PetActivityLogFactory::createUnreadLog($this->em, $pet, $impDiscovery . ' %pet:' . $pet->getId() . '.name% slew the creature outright, and claimed its ' . $loot . '!')
-                    ->setIcon('icons/activity-logs/confused')
-                    ->addTags(PetActivityLogTagHelpers::findByNames($this->em, [ 'Programming', 'Fighting' ]))
-                ;
-                PetBadgeHelpers::awardBadge($this->em, $pet, PetBadgeEnum::WrangledWithInfinities, $activityLog);
-                $this->petExperienceService->gainExp($pet, 3, [ PetSkillEnum::Science ], $activityLog);
-                $this->inventoryService->petCollectsItem($loot, $pet, $pet->getName() . ' received this by slaying an Infinity Imp.', $activityLog);
-                return $activityLog;
-            }
+            $this->petExperienceService->spendTime($pet, $this->rng->rngNextInt(45, 60), PetActivityStatEnum::PROGRAM, false);
+            $activityLog = PetActivityLogFactory::createUnreadLog($this->em, $pet, $impDiscovery . ' %pet:' . $pet->getId() . '.name% slew the creature outright, and claimed its ' . $loot . '!')
+                ->setIcon('icons/activity-logs/confused')
+                ->addTags(PetActivityLogTagHelpers::findByNames($this->em, [ 'Programming', 'Fighting' ]))
+            ;
+            $this->petExperienceService->gainExp($pet, 3, [ PetSkillEnum::Science ], $activityLog);
+            $this->inventoryService->petCollectsItem($loot, $pet, $pet->getName() . ' received this by slaying an Infinity Imp.', $activityLog);
+            return $activityLog;
         }
 
         $activityLog = PetActivityLogFactory::createUnreadLog($this->em, $pet, $impDiscovery . ' %pet:' . $pet->getId() . '.name% ran away until the imp finally gave up and returned to the strange dimension from whence it came.')
             ->setIcon('icons/activity-logs/confused')
         ;
-        
-        PetBadgeHelpers::awardBadge($this->em, $pet, PetBadgeEnum::WrangledWithInfinities, $activityLog);
-        
+
         $this->petExperienceService->gainExp($pet, 2, [ PetSkillEnum::Science ], $activityLog);
         $this->petExperienceService->spendTime($pet, $this->rng->rngNextInt(45, 60), PetActivityStatEnum::PROGRAM, false);
 

--- a/api/src/Service/PetActivity/Crafting/ProgrammingService.php
+++ b/api/src/Service/PetActivity/Crafting/ProgrammingService.php
@@ -579,6 +579,8 @@ class ProgrammingService implements IPetActivity
         $impDiscovery = '%pet:' . $pet->getId() . '.name% started ' . $actionInterrupted . ', but an Infinity Imp popped up, and started to attack!';
 
         $this->fieldGuideService->maybeUnlock($pet->getOwner(), 'Infinity Imp', $impDiscovery);
+        PetBadgeHelpers::awardBadge($this->em, $pet, PetBadgeEnum::WrangledWithInfinities, $activityLog);
+
 
         $isLucky = $this->rng->rngNextInt(1, 50) == 1 && $pet->hasMerit(MeritEnum::LUCKY);
 
@@ -637,8 +639,7 @@ class ProgrammingService implements IPetActivity
             ->setIcon('icons/activity-logs/confused')
         ;
 
-        PetBadgeHelpers::awardBadge($this->em, $pet, PetBadgeEnum::WrangledWithInfinities, $activityLog);
-
+        
         $this->petExperienceService->gainExp($pet, 2, [ PetSkillEnum::Science ], $activityLog);
         $this->petExperienceService->spendTime($pet, $this->rng->rngNextInt(45, 60), PetActivityStatEnum::PROGRAM, false);
 


### PR DESCRIPTION
## About
Attempts to award infinity wrangler badge "win or lose", instead of only when you lose.

## Why

This doesn't particularly hit a design goal, but the in-game spoiler text for the infinity wrangler badge says this:
> Spoiler: There are some science-y crafts that a pet may encounter an Infinity Imp while crafting. Win or lose, the pet will get this badge by fighting this creature.

The old implementation attempts to award the badge at the end of the FightInfinityImp function. However, if your pet won against the infinity imp, the function would return the log and never get to the line which attempted to award the badge (the badge would be awarded if you lost though, lol). Now, the game attempts to award the badge after the activity log is created, but before XP is added (which is before any return statement).

## Notes
The badge is not awarded if an infinity imp pet would instead receive the vault blueprint, because the badge description/spoiler specifically mentions fighting the infinity imp pet. Since the infinity imp pet never fights the wild infinity imp (the blueprint is created when they exist in each other's vicinity, before fighting can happen), it technically doesn't qualify...but I could be convinced that this counts as fighting, for the purpose of infinity imp pets being able to gain this badge at all haha. This would require another revision though.