### PR TITLE
Beach as a new reenactment location

### DIFF
--- a/api/migrations/2026/07/Version20260710042441.php
+++ b/api/migrations/2026/07/Version20260710042441.php
@@ -1,0 +1,37 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This file is part of the Poppy Seed Pets API.
+ *
+ * The Poppy Seed Pets API is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * The Poppy Seed Pets API is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with The Poppy Seed Pets API. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260710042441 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'adds a beach location tag to activity log tags';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<EOSQL
+        INSERT INTO `pet_activity_log_tag` (`id`, `title`, `color`, `emoji`) VALUES (102, 'Location: Beach', '38C789', 'fa-solid fa-tree-palm')
+        ON DUPLICATE KEY UPDATE `id` = `id`;
+        EOSQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+    }
+}

--- a/api/src/Enum/PetActivityLogTagEnum.php
+++ b/api/src/Enum/PetActivityLogTagEnum.php
@@ -117,6 +117,7 @@ final class PetActivityLogTagEnum
     public const string Location_The_Deep_Sea = 'Location: The Deep Sea';
     public const string Location_The_Fructal_Plane = 'Location: The Fructal Plane';
     public const string Location_The_Burnt_Forest = 'Location: The Burnt Forest';
+    public const string Location_Beach = 'Location: Beach';
 
     public const string Location_Hedge_Maze = 'Location: Hedge Maze';
     public const string Location_Hedge_Maze_Sphinx = 'Location: Hedge Maze Sphinx';

--- a/api/src/Service/PetActivity/FishingService.php
+++ b/api/src/Service/PetActivity/FishingService.php
@@ -400,7 +400,7 @@ class FishingService implements IPetActivity
         if($fightSkill <= 3)
         {
             $activityLog = PetActivityLogFactory::createUnreadLog($this->em, $pet, '%pet:' . $pet->getId() . '.name% went fishing, and started to reel something in, only to realize it was a huge Galloping Octopus! ' . $pet->getName() . ' was caught unawares, and took a tentacle slap to the face before running away! :(')
-                ->addTags(PetActivityLogTagHelpers::findByNames($this->em, [ 'Fishing', 'Fighting' ]))
+                ->addTags(PetActivityLogTagHelpers::findByNames($this->em, [ 'Fishing', 'Fighting', PetActivityLogTagEnum::Location_Beach ]))
             ;
             $this->petExperienceService->spendTime($pet, $this->rng->rngNextInt(30, 45), PetActivityStatEnum::HUNT, false);
             $this->petExperienceService->gainExp($pet, 1, [ PetSkillEnum::Brawl ], $activityLog);
@@ -417,7 +417,7 @@ class FishingService implements IPetActivity
                 $this->petExperienceService->spendTime($pet, $this->rng->rngNextInt(45, 60), PetActivityStatEnum::HUNT, true);
                 $activityLog = PetActivityLogFactory::createUnreadLog($this->em, $pet, '%pet:' . $pet->getId() . '.name% went fishing, and started to reel something in, only to realize it was a huge Galloping Octopus! ' . $pet->getName() . ' beat the creature back into the sea, but not before discerping one of its Tentacles!')
                     ->addInterestingness(PetActivityLogInterestingness::HoHum + 18)
-                    ->addTags(PetActivityLogTagHelpers::findByNames($this->em, [ 'Fishing', 'Fighting' ]))
+                    ->addTags(PetActivityLogTagHelpers::findByNames($this->em, [ 'Fishing', 'Fighting', PetActivityLogTagEnum::Location_Beach ]))
                 ;
                 $this->inventoryService->petCollectsItem('Tentacle', $pet, $pet->getName() . ' received this from a fight with a Galloping Octopus.', $activityLog);
 
@@ -431,7 +431,7 @@ class FishingService implements IPetActivity
                 $this->petExperienceService->spendTime($pet, $this->rng->rngNextInt(60, 75), PetActivityStatEnum::HUNT, true);
                 $activityLog = PetActivityLogFactory::createUnreadLog($this->em, $pet, '%pet:' . $pet->getId() . '.name% went fishing, and started to reel something in, only to realize it was a huge Galloping Octopus! ' . $pet->getName() . ' beat the creature back into the sea, but not before discerping two of its Tentacles!')
                     ->addInterestingness(PetActivityLogInterestingness::HoHum + 18)
-                    ->addTags(PetActivityLogTagHelpers::findByNames($this->em, [ 'Fishing', 'Fighting' ]))
+                    ->addTags(PetActivityLogTagHelpers::findByNames($this->em, [ 'Fishing', 'Fighting', PetActivityLogTagEnum::Location_Beach ]))
                 ;
                 $this->inventoryService->petCollectsItem('Tentacle', $pet, $pet->getName() . ' received this from a fight with a Galloping Octopus.', $activityLog);
                 $this->inventoryService->petCollectsItem('Tentacle', $pet, $pet->getName() . ' received this from a fight with a Galloping Octopus.', $activityLog);
@@ -447,7 +447,7 @@ class FishingService implements IPetActivity
         else
         {
             $activityLog = PetActivityLogFactory::createUnreadLog($this->em, $pet, '%pet:' . $pet->getId() . '.name% went fishing, and started to reel something in, only to realize it was a huge Galloping Octopus! The two tussled for a while before breaking apart and cautiously retreating...')
-                ->addTags(PetActivityLogTagHelpers::findByNames($this->em, [ 'Fishing', 'Fighting' ]))
+                ->addTags(PetActivityLogTagHelpers::findByNames($this->em, [ 'Fishing', 'Fighting', PetActivityLogTagEnum::Location_Beach ]))
             ;
             $this->petExperienceService->spendTime($pet, $this->rng->rngNextInt(45, 75), PetActivityStatEnum::HUNT, false);
             $this->petExperienceService->gainExp($pet, 2, [ PetSkillEnum::Brawl ], $activityLog);
@@ -1130,7 +1130,7 @@ class FishingService implements IPetActivity
         {
             $activityLog = PetActivityLogFactory::createUnreadLog($this->em, $pet, '%pet:' . $pet->getId() . '.name% went fishing way out on the pier, and caught a Jellyfish.')
                 ->setIcon('items/tool/fishing-rod/crooked')
-                ->addTags(PetActivityLogTagHelpers::findByNames($this->em, [ 'Fishing' ]))
+                ->addTags(PetActivityLogTagHelpers::findByNames($this->em, [ 'Fishing', PetActivityLogTagEnum::Location_Beach ]))
             ;
             $this->inventoryService->petCollectsItem('Jellyfish Jelly', $pet, $pet->getName() . ' got this from a Jellyfish they caught way out on the pier.', $activityLog);
 
@@ -1146,7 +1146,7 @@ class FishingService implements IPetActivity
         else
         {
             $activityLog = PetActivityLogFactory::createUnreadLog($this->em, $pet, '%pet:' . $pet->getId() . '.name% went fishing way out on the pier, and pulled up a Jellyfish, but it stung ' . $pet->getName() . ', and got away!')
-                ->addTags(PetActivityLogTagHelpers::findByNames($this->em, [ 'Fishing' ]))
+                ->addTags(PetActivityLogTagHelpers::findByNames($this->em, [ 'Fishing', PetActivityLogTagEnum::Location_Beach ]))
             ;
             $this->petExperienceService->gainExp($pet, 1, [ PetSkillEnum::Nature ], $activityLog);
 

--- a/api/src/Service/PetActivity/GatheringService.php
+++ b/api/src/Service/PetActivity/GatheringService.php
@@ -651,7 +651,7 @@ class GatheringService implements IPetActivity
 
                 $pet->increaseEsteem($this->rng->rngNextInt(1, 2));
                 $activityLog = PetActivityLogFactory::createUnreadLog($this->em, $pet, '%pet:' . $pet->getId() . '.name% went to a Sandy Beach, but while looking around, was attacked by a Giant Seagull. ' . $pet->getName() . ' defeated the Giant Seagull, and took its ' . ArrayFunctions::list_nice_sorted($loot) . '.')
-                    ->addTags(PetActivityLogTagHelpers::findByNames($this->em, [ 'Gathering', 'Stealth', 'Fighting' ]))
+                    ->addTags(PetActivityLogTagHelpers::findByNames($this->em, [ 'Gathering', 'Stealth', 'Fighting', PetActivityLogTagEnum::Location_Beach ]))
                 ;
                 $didWhat = 'defeated a Giant Seagull at the Beach, and got this';
 
@@ -664,7 +664,7 @@ class GatheringService implements IPetActivity
             {
                 $pet->increaseEsteem(-$this->rng->rngNextInt(1, 2));
                 $activityLog = PetActivityLogFactory::createUnreadLog($this->em, $pet, '%pet:' . $pet->getId() . '.name% went to a Sandy Beach, but was attacked and routed by a Giant Seagull.')
-                    ->addTags(PetActivityLogTagHelpers::findByNames($this->em, [ 'Gathering', 'Stealth', 'Fighting' ]))
+                    ->addTags(PetActivityLogTagHelpers::findByNames($this->em, [ 'Gathering', 'Stealth', 'Fighting', PetActivityLogTagEnum::Location_Beach ]))
                 ;
 
                 $this->petExperienceService->gainExp($pet, 1, [ PetSkillEnum::Stealth, PetSkillEnum::Brawl, PetSkillEnum::Nature ], $activityLog);
@@ -694,7 +694,7 @@ class GatheringService implements IPetActivity
                 $lootList = $loot;
                 $lootList[] = $moneys . '~~m~~';
                 $activityLog = PetActivityLogFactory::createUnreadLog($this->em, $pet, '%pet:' . $pet->getId() . '.name% went to a Sandy Beach, and stole ' . ArrayFunctions::list_nice_sorted($lootList) . ' while the seagulls weren\'t paying attention.')
-                    ->addTags(PetActivityLogTagHelpers::findByNames($this->em, [ 'Gathering', 'Stealth', 'Moneys' ]))
+                    ->addTags(PetActivityLogTagHelpers::findByNames($this->em, [ 'Gathering', 'Stealth', 'Moneys', PetActivityLogTagEnum::Location_Beach ]))
                 ;
                 $this->petExperienceService->gainExp($pet, 2, [ PetSkillEnum::Stealth, PetSkillEnum::Nature ], $activityLog);
                 $this->petExperienceService->spendTime($pet, $this->rng->rngNextInt(45, 75), PetActivityStatEnum::GATHER, true);
@@ -702,7 +702,7 @@ class GatheringService implements IPetActivity
             else
             {
                 $activityLog = PetActivityLogFactory::createUnreadLog($this->em, $pet, '%pet:' . $pet->getId() . '.name% went to a Sandy Beach, and stole ' . ArrayFunctions::list_nice_sorted($loot) . ' while the seagulls weren\'t paying attention.')
-                    ->addTags(PetActivityLogTagHelpers::findByNames($this->em, [ 'Gathering', 'Stealth' ]))
+                    ->addTags(PetActivityLogTagHelpers::findByNames($this->em, [ 'Gathering', 'Stealth', PetActivityLogTagEnum::Location_Beach ]))
                 ;
                 $this->petExperienceService->gainExp($pet, 1, [ PetSkillEnum::Stealth, PetSkillEnum::Nature ], $activityLog);
                 $this->petExperienceService->spendTime($pet, $this->rng->rngNextInt(45, 60), PetActivityStatEnum::GATHER, true);

--- a/api/src/Service/PetActivity/HuntingService.php
+++ b/api/src/Service/PetActivity/HuntingService.php
@@ -719,7 +719,7 @@ class HuntingService implements IPetActivity
 
             $activityLog = PetActivityLogFactory::createUnreadLog($this->em, $pet, ActivityHelpers::PetName($pet) . $defeatMethod . ' a Sand Castle, looting its ' . $loot . '!' . ($isLucky ? ' (Lucky~!)' : ''))
                 ->setIcon($gotShell ? 'items/animal/seashell-secret' : 'items/mineral/silca')
-                ->addTags(PetActivityLogTagHelpers::findByNames($this->em, [ PetActivityLogTagEnum::Hunting, PetActivityLogTagEnum::Stealth ]))
+                ->addTags(PetActivityLogTagHelpers::findByNames($this->em, [ PetActivityLogTagEnum::Hunting, PetActivityLogTagEnum::Stealth, PetActivityLogTagEnum::Location_Beach ]))
             ;
 
             if($isLucky)
@@ -1870,7 +1870,7 @@ class HuntingService implements IPetActivity
 
             $activityLog = PetActivityLogFactory::createUnreadLog($this->em, $pet, ActivityHelpers::PetName($pet) . ' went out hunting, and encountered a Miniature Naner Crab! After stalking it for awhile, ' . ActivityHelpers::PetName($pet) . ' ate an entire claw off, slaying it! (Ah~! A true Gourmand!) Finally, they recovered ' . $prize->getNameWithArticle() . ' off of its legs, and brought it home.')
                 ->addInterestingness(PetActivityLogInterestingness::ActivityUsingMerit)
-                ->addTags(PetActivityLogTagHelpers::findByNames($this->em, [ PetActivityLogTagEnum::Hunting, PetActivityLogTagEnum::Eating, PetActivityLogTagEnum::Stealth, PetActivityLogTagEnum::Gourmand ]))
+                ->addTags(PetActivityLogTagHelpers::findByNames($this->em, [ PetActivityLogTagEnum::Hunting, PetActivityLogTagEnum::Eating, PetActivityLogTagEnum::Stealth, PetActivityLogTagEnum::Gourmand, PetActivityLogTagEnum::Location_Beach ]))
             ;
 
             $this->inventoryService->petCollectsItem($prize, $pet, $pet->getName() . ' collected this from the remains of a Miniature Naner Crab.', $activityLog);

--- a/webapp/src/app/module/pet-logs/dialogs/reenactment/reenactment.dialog.ts
+++ b/webapp/src/app/module/pet-logs/dialogs/reenactment/reenactment.dialog.ts
@@ -73,7 +73,7 @@ export class ReenactmentDialog implements OnInit
     },*/
     'Location: Beach': {
       image: 'beach',
-      petPosition: { x: 10, y: 10, scale: 4 },
+      petPosition: { x: 46, y: 89, scale: 24 },
       interestingness: 0,
     },
     'Location: At Home': {

--- a/webapp/src/app/module/pet-logs/dialogs/reenactment/reenactment.dialog.ts
+++ b/webapp/src/app/module/pet-logs/dialogs/reenactment/reenactment.dialog.ts
@@ -71,6 +71,11 @@ export class ReenactmentDialog implements OnInit
       petPosition: { x: 10, y: 10, scale: 20 },
       interestingness: 0,
     },*/
+    'Location: Beach': {
+      image: 'beach',
+      petPosition: { x: 10, y: 10, scale: 4 },
+      interestingness: 0,
+    },
     'Location: At Home': {
       image: 'living-room',
       petPosition: { x: 46, y: 89, scale: 24 },


### PR DESCRIPTION
## About
Adds a beach as a potential reenactment location, using the existing camera BG. It currently uses identical position and scale to the living room, because it looks approximately correct after checking with a camera. 

## Why
It resolves #264 and seemed simple for me to do. Also, hopefully it means that we see 'at home' less when reenactments come up.

## Notes
It seems like pet activity log tags are added very rarely; I guessed the ID based off of the gardening tag added in #254 

I included the jellyfish and giant octopus fishing events, but not the coral reef, because the phrasing 'coral reef' implies a very different background to me...though the jellyfish fishing event mentions a 'long pier' in the description (not present in the image), and the octopus also sounds like it'd be a little further out to sea (just from my intuition of octopuses not being present at shore :P). 

For what it's worth, the volcano and umbra backgrounds are currently available in the camera and don't exist as potential reenactment locations. The lab portal also exists, but I'm not sure what activities that corresponds to.

From examining the existing reenactments, there also seem to be a number of images in the /camera/backgrounds folder that are not currently available as camera backgrounds, so someone could also write an update to include those if they wanted! 