### PR TITLE
implementation for issue #28 - support bulk-spicing of food items. 

### DIFF
--- a/api/src/Controller/Inventory/CookAndCombineController.php
+++ b/api/src/Controller/Inventory/CookAndCombineController.php
@@ -135,7 +135,8 @@ class CookAndCombineController
 
             $count = count($bulkSpicingPlan->pairs);
             $foodName = $bulkSpicingPlan->pairs[0][0]->getItem()->getName();
-            $spiceName = $bulkSpicingPlan->pairs[0][0]->getSpice()->getName();
+            $spiceName = $bulkSpicingPlan->pairs[0][1]->getItems()->getSpice()?->getName()
+                ?? throw new PSPInvalidOperationException('There is no spice to be found!');
 
             if($bulkSpicingPlan->leftoverFoodCount > 0)
                 $responseService->addFlashMessage($count . ' of those ' . $foodName . ' now have the ' . $spiceName . ' spice - but there wasn\'t enough for the last ' . $bulkSpicingPlan->leftoverFoodCount . ' ' . $foodName . ' so they\'re plain for now.');

--- a/api/src/Controller/Inventory/CookAndCombineController.php
+++ b/api/src/Controller/Inventory/CookAndCombineController.php
@@ -126,6 +126,34 @@ class CookAndCombineController
             }
         }
 
+        $bulkSpicingPlan = InventoryModifierFunctions::planBulkSpicing($inventory);
+
+        if($bulkSpicingPlan !== null)
+        {
+            foreach($bulkSpicingPlan->pairs as [$food, $spice])
+                InventoryModifierFunctions::spiceUp($em, $food, $spice);
+
+            $count = count($bulkSpicingPlan->pairs);
+            $foodName = $bulkSpicingPlan->pairs[0][0]->getItem()->getName();
+            $spiceName = $bulkSpicingPlan->pairs[0][0]->getSpice()->getName();
+
+            if($bulkSpicingPlan->leftoverFoodCount > 0)
+                $responseService->addFlashMessage($count . ' of those ' . $foodName . ' now have the ' . $spiceName . ' spice - but there wasn\'t enough for the last ' . $bulkSpicingPlan->leftoverFoodCount . ' ' . $foodName . ' so they\'re plain for now.');
+            else if($bulkSpicingPlan->leftoverSpiceCount > 0)
+                $responseService->addFlashMessage('All ' . $count . ' of those ' . $foodName . ' now have the ' . $spiceName . ' spice! You have ' . $bulkSpicingPlan->leftoverSpiceCount . ' ' . $spiceName . ' spices leftover.');
+            else
+                $responseService->addFlashMessage('All ' . $count . ' of those ' . $foodName . ' now have the ' . $spiceName . ' spice! Batch-prepping FTW!');
+
+            $em->flush();
+
+            $responseService->setReloadInventory();
+
+            return $responseService->success(array_map(fn(array $pair) => $pair[0], $bulkSpicingPlan->pairs), [ SerializationGroupEnum::MY_INVENTORY ]);
+        }
+
+        if(InventoryModifierFunctions::isAmbiguousBulkSpicingAttempt($inventory))
+            throw new PSPInvalidOperationException('Hmm, this is some complicated seasoning you\'re requesting. Let\'s not.');
+
         $results = $cookingService->prepareRecipeByHand($user, $user, $inventory);
 
         // do this before checking if anything was made

--- a/api/src/Controller/Inventory/CookAndCombineController.php
+++ b/api/src/Controller/Inventory/CookAndCombineController.php
@@ -21,6 +21,7 @@ use App\Exceptions\PSPNotFoundException;
 use App\Functions\ArrayFunctions;
 use App\Functions\GrammarFunctions;
 use App\Functions\InventoryModifierFunctions;
+use App\Model\BulkSpicingPlan;
 use App\Service\CookingService;
 use App\Service\InventoryService;
 use App\Service\IRandom;
@@ -134,16 +135,23 @@ class CookAndCombineController
                 InventoryModifierFunctions::spiceUp($em, $food, $spice);
 
             $count = count($bulkSpicingPlan->pairs);
-            $foodName = $bulkSpicingPlan->pairs[0][0]->getItem()->getName();
-            $spiceName = $bulkSpicingPlan->pairs[0][1]->getItems()->getSpice()?->getName()
+            /** @var array{0: Inventory, 1: Inventory} $firstPair */
+            $firstPair = $bulkSpicingPlan->pairs[0];
+            /** @var Inventory $firstFood */
+            $firstFood = $firstPair[0];
+            /** @var Inventory $firstSpice */
+            $firstSpice = $firstPair[1];
+
+            $foodName = $firstFood->getItem()->getName();
+            $spiceName = $firstSpice->getItem()->getSpice()?->getName()
                 ?? throw new PSPInvalidOperationException('There is no spice to be found!');
 
             if($bulkSpicingPlan->leftoverFoodCount > 0)
-                $responseService->addFlashMessage($count . ' of those ' . $foodName . ' now have the ' . $spiceName . ' spice - but there wasn\'t enough for the last ' . $bulkSpicingPlan->leftoverFoodCount . ' ' . $foodName . ' so they\'re plain for now.');
+                $responseService->addFlashMessage((string)$count . ' of those ' . (string)$foodName . ' now have the ' . (string)$spiceName . ' spice - but there wasn\'t enough for the last ' . (string)$bulkSpicingPlan->leftoverFoodCount . ' ' . (string)$foodName . ' so they\'re plain for now.');
             else if($bulkSpicingPlan->leftoverSpiceCount > 0)
-                $responseService->addFlashMessage('All ' . $count . ' of those ' . $foodName . ' now have the ' . $spiceName . ' spice! You have ' . $bulkSpicingPlan->leftoverSpiceCount . ' ' . $spiceName . ' spices leftover.');
+                $responseService->addFlashMessage('All ' . (string)$count . ' of those ' . (string)$foodName . ' now have the ' . (string)$spiceName . ' spice! You have ' . (string)$bulkSpicingPlan->leftoverSpiceCount . ' ' . (string)$spiceName . ' spices leftover.');
             else
-                $responseService->addFlashMessage('All ' . $count . ' of those ' . $foodName . ' now have the ' . $spiceName . ' spice! Batch-prepping FTW!');
+                $responseService->addFlashMessage('All ' . (string)$count . ' of those ' . (string)$foodName . ' now have the ' . (string)$spiceName . ' spice! Batch-prepping FTW!');
 
             $em->flush();
 

--- a/api/src/Controller/Inventory/CookAndCombineController.php
+++ b/api/src/Controller/Inventory/CookAndCombineController.php
@@ -134,24 +134,54 @@ class CookAndCombineController
             foreach($bulkSpicingPlan->pairs as [$food, $spice])
                 InventoryModifierFunctions::spiceUp($em, $food, $spice);
 
-            $count = count($bulkSpicingPlan->pairs);
-            /** @var array{0: Inventory, 1: Inventory} $firstPair */
-            $firstPair = $bulkSpicingPlan->pairs[0];
-            /** @var Inventory $firstFood */
-            $firstFood = $firstPair[0];
-            /** @var Inventory $firstSpice */
-            $firstSpice = $firstPair[1];
+            $spicedFoodQuantities = [];
+            $appliedSpiceQuantities = [];
+            $spicedFoods = [];
+            $appliedSpices = [];
 
-            $foodName = $firstFood->getItem()->getName();
-            $spiceName = $firstSpice->getItem()->getSpice()?->getName()
-                ?? throw new PSPInvalidOperationException('There is no spice to be found!');
+            foreach($bulkSpicingPlan->pairs as [$food, $spice])
+            {
+                $foodName = $food->getItem()->getName();
+                $spiceName = $spice->getItem()->getName();
+
+                $spicedFoodQuantities[$foodName] = ($spicedFoodQuantities[$foodName] ?? 0) + 1;
+                $appliedSpiceQuantities[$spiceName] = ($appliedSpiceQuantities[$spiceName] ?? 0) + 1;
+                $spicedFoods[] = $food;
+                $appliedSpices[] = $spice;
+            }
 
             if($bulkSpicingPlan->leftoverFoodCount > 0)
-                $responseService->addFlashMessage((string)$count . ' of those ' . (string)$foodName . ' now have the ' . (string)$spiceName . ' spice - but there wasn\'t enough for the last ' . (string)$bulkSpicingPlan->leftoverFoodCount . ' ' . (string)$foodName . ' so they\'re plain for now.');
+            {
+                $unspicedFoodQuantities = [];
+
+                foreach($inventory as $item)
+                {
+                    if($item->getItem()->getFood() !== null && !in_array($item, $spicedFoods, true))
+                    {
+                        $foodName = $item->getItem()->getName();
+                        $unspicedFoodQuantities[$foodName] = ($unspicedFoodQuantities[$foodName] ?? 0) + 1;
+                    }
+                }
+
+                $responseService->addFlashMessage(ArrayFunctions::list_nice_quantities($spicedFoodQuantities) . ' are now seasoned: ' . ArrayFunctions::list_nice_quantities($appliedSpiceQuantities) . ' - but there wasn\'t enough for the last ' . ArrayFunctions::list_nice_quantities($unspicedFoodQuantities) . ' so they\'re plain for now.');
+            }
             else if($bulkSpicingPlan->leftoverSpiceCount > 0)
-                $responseService->addFlashMessage('All ' . (string)$count . ' of those ' . (string)$foodName . ' now have the ' . (string)$spiceName . ' spice! You have ' . (string)$bulkSpicingPlan->leftoverSpiceCount . ' ' . (string)$spiceName . ' spices leftover.');
+            {
+                $leftoverSpiceQuantities = [];
+
+                foreach($inventory as $item)
+                {
+                    if($item->getItem()->getSpice() !== null && !in_array($item, $appliedSpices, true))
+                    {
+                        $spiceName = $item->getItem()->getName();
+                        $leftoverSpiceQuantities[$spiceName] = ($leftoverSpiceQuantities[$spiceName] ?? 0) + 1;
+                    }
+                }
+
+                $responseService->addFlashMessage(ArrayFunctions::list_nice_quantities($spicedFoodQuantities) . ' are now seasoned: ' . ArrayFunctions::list_nice_quantities($appliedSpiceQuantities) . '! You have ' . ArrayFunctions::list_nice_quantities($leftoverSpiceQuantities) . ' leftover.');
+            }
             else
-                $responseService->addFlashMessage('All ' . (string)$count . ' of those ' . (string)$foodName . ' now have the ' . (string)$spiceName . ' spice! Batch-prepping FTW!');
+                $responseService->addFlashMessage(ArrayFunctions::list_nice_quantities($spicedFoodQuantities) . ' are now seasoned: ' . ArrayFunctions::list_nice_quantities($appliedSpiceQuantities) . '! Batch-prepping FTW!');
 
             $em->flush();
 

--- a/api/src/Functions/InventoryModifierFunctions.php
+++ b/api/src/Functions/InventoryModifierFunctions.php
@@ -18,6 +18,7 @@ use App\Entity\Inventory;
 use App\Entity\Item;
 use App\Entity\Spice;
 use App\Exceptions\PSPInvalidOperationException;
+use App\Model\BulkSpicingPlan;
 use Doctrine\ORM\EntityManagerInterface;
 
 class InventoryModifierFunctions
@@ -40,6 +41,78 @@ class InventoryModifierFunctions
         $food->setSpice($spice->getItem()->getSpice());
 
         $em->remove($spice);
+    }
+
+    /**
+     * Figures out whether a selection of inventory items is an unambiguous request to bulk-spice
+     * every selected food with one of the selected spices. Handles the case where food and spice
+     * counts are equal, the case where there are more foods than spices (the extra foods are left
+     * unspiced), and the case where there are more spices than foods (the extra spices are left
+     * unused). Every other case is ambiguous, and returns null.
+     *
+     * @param Inventory[] $inventory
+     */
+    public static function planBulkSpicing(array $inventory): ?BulkSpicingPlan
+    {
+        $foods = array_values(array_filter($inventory, fn(Inventory $i) => $i->getItem()->getFood() !== null));
+        $spices = array_values(array_filter($inventory, fn(Inventory $i) => $i->getItem()->getSpice() !== null));
+
+        // something in the selection is neither food nor spice
+        if(count($foods) + count($spices) !== count($inventory))
+            return null;
+
+        if(count($foods) === 0 || count($spices) === 0)
+            return null;
+
+        if(array_any($foods, fn(Inventory $i) => $i->getSpice() !== null))
+            return null;
+
+        $firstFoodItem = $foods[0]->getItem();
+
+        if(array_any($foods, fn(Inventory $i) => $i->getItem() !== $firstFoodItem))
+            return null;
+
+        $firstSpiceItem = $spices[0]->getItem();
+
+        if(array_any($spices, fn(Inventory $i) => $i->getItem() !== $firstSpiceItem))
+            return null;
+
+        $pairCount = min(count($foods), count($spices));
+
+        $pairs = array_map(
+            fn(Inventory $food, Inventory $spice) => [ $food, $spice ],
+            array_slice($foods, 0, $pairCount),
+            array_slice($spices, 0, $pairCount)
+        );
+
+        return new BulkSpicingPlan(
+            $pairs,
+            leftoverFoodCount: count($foods) - $pairCount,
+            leftoverSpiceCount: count($spices) - $pairCount
+        );
+    }
+
+    /**
+     * True when a selection is entirely food and spice items (so it's clearly an attempt at
+     * bulk-spicing, not some other recipe), but doesn't match any of planBulkSpicing's
+     * unambiguous patterns. False for anything planBulkSpicing can handle, and false when the
+     * selection includes items that are neither food nor spice (that's not this feature's
+     * concern - it's left to the existing recipe-matching logic).
+     *
+     * @param Inventory[] $inventory
+     */
+    public static function isAmbiguousBulkSpicingAttempt(array $inventory): bool
+    {
+        $foods = array_filter($inventory, fn(Inventory $i) => $i->getItem()->getFood() !== null);
+        $spices = array_filter($inventory, fn(Inventory $i) => $i->getItem()->getSpice() !== null);
+
+        if(count($foods) + count($spices) !== count($inventory))
+            return false;
+
+        if(count($foods) === 0 || count($spices) === 0)
+            return false;
+
+        return self::planBulkSpicing($inventory) === null;
     }
 
     public static function getNameWithModifiers(Inventory $item): string

--- a/api/src/Functions/InventoryModifierFunctions.php
+++ b/api/src/Functions/InventoryModifierFunctions.php
@@ -68,13 +68,18 @@ class InventoryModifierFunctions
             return null;
 
         $firstFoodItem = $foods[0]->getItem();
-
-        if(array_any($foods, fn(Inventory $i) => $i->getItem() !== $firstFoodItem))
-            return null;
+        $hasMixedFoods = array_any($foods, fn(Inventory $i) => $i->getItem() !== $firstFoodItem);
 
         $firstSpiceItem = $spices[0]->getItem();
+        $hasMixedSpices = array_any($spices, fn(Inventory $i) => $i->getItem() !== $firstSpiceItem);
 
-        if(array_any($spices, fn(Inventory $i) => $i->getItem() !== $firstSpiceItem))
+        if($hasMixedFoods && $hasMixedSpices)
+            return null;
+
+        if($hasMixedFoods && count($spices) < count($foods))
+            return null;
+
+        if($hasMixedSpices && count($spices) > count($foods))
             return null;
 
         $pairCount = min(count($foods), count($spices));

--- a/api/src/Model/BulkSpicingPlan.php
+++ b/api/src/Model/BulkSpicingPlan.php
@@ -1,0 +1,32 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This file is part of the Poppy Seed Pets API.
+ *
+ * The Poppy Seed Pets API is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * The Poppy Seed Pets API is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with The Poppy Seed Pets API. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace App\Model;
+
+use App\Entity\Inventory;
+
+final class BulkSpicingPlan
+{
+    /**
+     * @param array{0: Inventory, 1: Inventory}[] $pairs Foods paired with the spice to apply to them.
+     * @param int $leftoverFoodCount Selected foods that won't get spiced, because there weren't enough spices for them.
+     * @param int $leftoverSpiceCount Selected spices that won't get used, because there weren't enough foods for them.
+     */
+    public function __construct(
+        public readonly array $pairs,
+        public readonly int $leftoverFoodCount = 0,
+        public readonly int $leftoverSpiceCount = 0,
+    )
+    {
+    }
+}

--- a/api/tests/Controller/Inventory/CookAndCombineControllerTest.php
+++ b/api/tests/Controller/Inventory/CookAndCombineControllerTest.php
@@ -1,6 +1,16 @@
 <?php
 declare(strict_types=1);
 
+/**
+ * This file is part of the Poppy Seed Pets API.
+ *
+ * The Poppy Seed Pets API is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * The Poppy Seed Pets API is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with The Poppy Seed Pets API. If not, see <https://www.gnu.org/licenses/>.
+ */
+
 namespace Controller\Inventory;
 
 use App\Controller\Inventory\CookAndCombineController;

--- a/api/tests/Controller/Inventory/CookAndCombineControllerTest.php
+++ b/api/tests/Controller/Inventory/CookAndCombineControllerTest.php
@@ -1,0 +1,94 @@
+<?php
+declare(strict_types=1);
+
+namespace Controller\Inventory;
+
+use App\Controller\Inventory\CookAndCombineController;
+use App\Entity\Inventory;
+use App\Entity\Item;
+use App\Entity\ItemFood;
+use App\Entity\Spice;
+use App\Entity\User;
+use App\Functions\InventoryModifierFunctions;
+use App\Service\CookingService;
+use App\Service\IRandom;
+use App\Service\ResponseService;
+use App\Service\UserAccessor;
+use Doctrine\ORM\EntityRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+
+class CookAndCombineControllerTest extends TestCase
+{
+    private static function makeFoodItem(string $name): Item
+    {
+        $item = new Item();
+        $item->setName($name);
+        $item->setFood(new ItemFood());
+
+        return $item;
+    }
+
+    private static function makeSpiceItem(string $name): Item
+    {
+        $item = new Item();
+        $item->setName($name);
+        $item->setSpice(new Spice($name, new ItemFood()));
+
+        return $item;
+    }
+
+    private static function makeInventory(User $owner, Item $item): Inventory
+    {
+        return new Inventory($owner, $item);
+    }
+
+    public function testPartialMixedSpiceBatchReportsTheCountOfPlainFoods(): void
+    {
+        $owner = new User('Tester', 'tester@example.com');
+        $egg = self::makeFoodItem('Egg');
+        $tomatoKetchup = self::makeSpiceItem('Tomato Ketchup');
+        $onion = self::makeSpiceItem('Onion');
+
+        $inventory = [
+            self::makeInventory($owner, $egg),
+            self::makeInventory($owner, $egg),
+            self::makeInventory($owner, $egg),
+            self::makeInventory($owner, $egg),
+            self::makeInventory($owner, $tomatoKetchup),
+            self::makeInventory($owner, $onion),
+        ];
+
+        $repository = $this->createMock(EntityRepository::class);
+        $repository->method('findBy')->willReturn($inventory);
+
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->method('getRepository')->with(Inventory::class)->willReturn($repository);
+        $entityManager->expects($this->exactly(2))->method('remove');
+        $entityManager->expects($this->once())->method('flush');
+
+        $responseService = $this->getMockBuilder(ResponseService::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods([ 'addFlashMessage', 'success' ])
+            ->getMock();
+        $responseService->expects($this->once())
+            ->method('addFlashMessage')
+            ->with('2× Egg are now seasoned: Tomato Ketchup, and Onion - but there wasn\'t enough for the last 2× Egg so they\'re plain for now.')
+            ->willReturnSelf();
+        $responseService->method('success')->willReturn(new JsonResponse());
+
+        $userAccessor = $this->createMock(UserAccessor::class);
+        $userAccessor->method('getUserOrThrow')->willReturn($owner);
+
+        (new CookAndCombineController())->prepareRecipe(
+            new Request([], [ 'inventory' => [ 1, 2, 3, 4, 5, 6 ] ]),
+            $responseService,
+            $entityManager,
+            $this->createMock(CookingService::class),
+            $this->createMock(IRandom::class),
+            $userAccessor
+        );
+    }
+}

--- a/api/tests/Functions/InventoryModifierFunctionsTest.php
+++ b/api/tests/Functions/InventoryModifierFunctionsTest.php
@@ -1,0 +1,272 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This file is part of the Poppy Seed Pets API.
+ *
+ * The Poppy Seed Pets API is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * The Poppy Seed Pets API is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with The Poppy Seed Pets API. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace Functions;
+
+use App\Entity\Inventory;
+use App\Entity\Item;
+use App\Entity\ItemFood;
+use App\Entity\Spice;
+use App\Entity\User;
+use App\Functions\InventoryModifierFunctions;
+use PHPUnit\Framework\TestCase;
+
+class InventoryModifierFunctionsTest extends TestCase
+{
+    private static function makeFoodItem(string $name): Item
+    {
+        $item = new Item();
+        $item->setName($name);
+        $item->setFood(new ItemFood());
+
+        return $item;
+    }
+
+    private static function makeSpiceItem(string $name): Item
+    {
+        $item = new Item();
+        $item->setName($name . ' Powder');
+        $item->setSpice(new Spice($name, new ItemFood()));
+
+        return $item;
+    }
+
+    private static function makeInventory(User $owner, Item $item): Inventory
+    {
+        return new Inventory($owner, $item);
+    }
+
+    public function testExactMatchReturnsAPairForEveryFoodAndSpice(): void
+    {
+        $owner = new User('Tester', 'tester@example.com');
+        $egg = self::makeFoodItem('Egg');
+        $onion = self::makeSpiceItem('Onion');
+
+        $inventory = [
+            self::makeInventory($owner, $egg),
+            self::makeInventory($owner, $egg),
+            self::makeInventory($owner, $egg),
+            self::makeInventory($owner, $onion),
+            self::makeInventory($owner, $onion),
+            self::makeInventory($owner, $onion),
+        ];
+
+        $plan = InventoryModifierFunctions::planBulkSpicing($inventory);
+
+        $this->assertNotNull($plan);
+        $this->assertCount(3, $plan->pairs);
+        $this->assertSame(0, $plan->leftoverFoodCount);
+        $this->assertSame(0, $plan->leftoverSpiceCount);
+
+        foreach($plan->pairs as [$food, $spice])
+        {
+            $this->assertSame($egg, $food->getItem());
+            $this->assertSame($onion, $spice->getItem());
+        }
+    }
+
+    public function testMismatchedFoodTypesReturnsNull(): void
+    {
+        $owner = new User('Tester', 'tester@example.com');
+        $egg = self::makeFoodItem('Egg');
+        $fish = self::makeFoodItem('Fish');
+        $onion = self::makeSpiceItem('Onion');
+
+        $inventory = [
+            self::makeInventory($owner, $egg),
+            self::makeInventory($owner, $fish),
+            self::makeInventory($owner, $onion),
+            self::makeInventory($owner, $onion),
+        ];
+
+        $this->assertNull(InventoryModifierFunctions::planBulkSpicing($inventory));
+    }
+
+    public function testMismatchedSpiceTypesReturnsNull(): void
+    {
+        $owner = new User('Tester', 'tester@example.com');
+        $egg = self::makeFoodItem('Egg');
+        $onion = self::makeSpiceItem('Onion');
+        $garlic = self::makeSpiceItem('Garlic');
+
+        $inventory = [
+            self::makeInventory($owner, $egg),
+            self::makeInventory($owner, $egg),
+            self::makeInventory($owner, $onion),
+            self::makeInventory($owner, $garlic),
+        ];
+
+        $this->assertNull(InventoryModifierFunctions::planBulkSpicing($inventory));
+    }
+
+    public function testAlreadySpicedFoodReturnsNull(): void
+    {
+        $owner = new User('Tester', 'tester@example.com');
+        $egg = self::makeFoodItem('Egg');
+        $onion = self::makeSpiceItem('Onion');
+
+        $alreadySpiced = self::makeInventory($owner, $egg);
+        $alreadySpiced->setSpice($onion->getSpice());
+
+        $inventory = [
+            self::makeInventory($owner, $egg),
+            $alreadySpiced,
+            self::makeInventory($owner, $onion),
+            self::makeInventory($owner, $onion),
+        ];
+
+        $this->assertNull(InventoryModifierFunctions::planBulkSpicing($inventory));
+    }
+
+    public function testMoreFoodsThanSpicesSpicesAsManyAsPossibleAndTracksLeftoverFoods(): void
+    {
+        $owner = new User('Tester', 'tester@example.com');
+        $egg = self::makeFoodItem('Egg');
+        $onion = self::makeSpiceItem('Onion');
+
+        $inventory = [
+            self::makeInventory($owner, $egg),
+            self::makeInventory($owner, $egg),
+            self::makeInventory($owner, $egg),
+            self::makeInventory($owner, $onion),
+            self::makeInventory($owner, $onion),
+        ];
+
+        $plan = InventoryModifierFunctions::planBulkSpicing($inventory);
+
+        $this->assertNotNull($plan);
+        $this->assertCount(2, $plan->pairs);
+        $this->assertSame(1, $plan->leftoverFoodCount);
+        $this->assertSame(0, $plan->leftoverSpiceCount);
+
+        foreach($plan->pairs as [$food, $spice])
+        {
+            $this->assertSame($egg, $food->getItem());
+            $this->assertSame($onion, $spice->getItem());
+        }
+    }
+
+    public function testMoreSpicesThanFoodsSpicesEveryFoodAndTracksLeftoverSpices(): void
+    {
+        $owner = new User('Tester', 'tester@example.com');
+        $egg = self::makeFoodItem('Egg');
+        $onion = self::makeSpiceItem('Onion');
+
+        $inventory = [
+            self::makeInventory($owner, $egg),
+            self::makeInventory($owner, $onion),
+            self::makeInventory($owner, $onion),
+            self::makeInventory($owner, $onion),
+        ];
+
+        $plan = InventoryModifierFunctions::planBulkSpicing($inventory);
+
+        $this->assertNotNull($plan);
+        $this->assertCount(1, $plan->pairs);
+        $this->assertSame(0, $plan->leftoverFoodCount);
+        $this->assertSame(2, $plan->leftoverSpiceCount);
+
+        foreach($plan->pairs as [$food, $spice])
+        {
+            $this->assertSame($egg, $food->getItem());
+            $this->assertSame($onion, $spice->getItem());
+        }
+    }
+
+    public function testMismatchedFoodTypesIsAmbiguous(): void
+    {
+        $owner = new User('Tester', 'tester@example.com');
+        $egg = self::makeFoodItem('Egg');
+        $fish = self::makeFoodItem('Fish');
+        $onion = self::makeSpiceItem('Onion');
+
+        $inventory = [
+            self::makeInventory($owner, $egg),
+            self::makeInventory($owner, $fish),
+            self::makeInventory($owner, $onion),
+            self::makeInventory($owner, $onion),
+        ];
+
+        $this->assertTrue(InventoryModifierFunctions::isAmbiguousBulkSpicingAttempt($inventory));
+    }
+
+    public function testMismatchedSpiceTypesIsAmbiguous(): void
+    {
+        $owner = new User('Tester', 'tester@example.com');
+        $egg = self::makeFoodItem('Egg');
+        $onion = self::makeSpiceItem('Onion');
+        $garlic = self::makeSpiceItem('Garlic');
+
+        $inventory = [
+            self::makeInventory($owner, $egg),
+            self::makeInventory($owner, $egg),
+            self::makeInventory($owner, $onion),
+            self::makeInventory($owner, $garlic),
+        ];
+
+        $this->assertTrue(InventoryModifierFunctions::isAmbiguousBulkSpicingAttempt($inventory));
+    }
+
+    public function testAlreadySpicedFoodIsAmbiguous(): void
+    {
+        $owner = new User('Tester', 'tester@example.com');
+        $egg = self::makeFoodItem('Egg');
+        $onion = self::makeSpiceItem('Onion');
+
+        $alreadySpiced = self::makeInventory($owner, $egg);
+        $alreadySpiced->setSpice($onion->getSpice());
+
+        $inventory = [
+            self::makeInventory($owner, $egg),
+            $alreadySpiced,
+            self::makeInventory($owner, $onion),
+            self::makeInventory($owner, $onion),
+        ];
+
+        $this->assertTrue(InventoryModifierFunctions::isAmbiguousBulkSpicingAttempt($inventory));
+    }
+
+    public function testSuccessfulBulkSpicingSelectionIsNotAmbiguous(): void
+    {
+        $owner = new User('Tester', 'tester@example.com');
+        $egg = self::makeFoodItem('Egg');
+        $onion = self::makeSpiceItem('Onion');
+
+        $inventory = [
+            self::makeInventory($owner, $egg),
+            self::makeInventory($owner, $egg),
+            self::makeInventory($owner, $onion),
+            self::makeInventory($owner, $onion),
+        ];
+
+        $this->assertFalse(InventoryModifierFunctions::isAmbiguousBulkSpicingAttempt($inventory));
+    }
+
+    public function testSelectionWithNonFoodNonSpiceItemsIsNotAmbiguous(): void
+    {
+        $owner = new User('Tester', 'tester@example.com');
+        $egg = self::makeFoodItem('Egg');
+        $onion = self::makeSpiceItem('Onion');
+        $rock = new Item();
+        $rock->setName('Rock');
+
+        $inventory = [
+            self::makeInventory($owner, $egg),
+            self::makeInventory($owner, $onion),
+            self::makeInventory($owner, $rock),
+        ];
+
+        // not our concern - this is deferred to the existing recipe-matching logic, unchanged
+        $this->assertFalse(InventoryModifierFunctions::isAmbiguousBulkSpicingAttempt($inventory));
+    }
+}

--- a/api/tests/Functions/InventoryModifierFunctionsTest.php
+++ b/api/tests/Functions/InventoryModifierFunctionsTest.php
@@ -75,7 +75,7 @@ class InventoryModifierFunctionsTest extends TestCase
         }
     }
 
-    public function testMismatchedFoodTypesReturnsNull(): void
+    public function testMixedFoodTypesWithUniformSpicesExactCountCreatesPlan(): void
     {
         $owner = new User('Tester', 'tester@example.com');
         $egg = self::makeFoodItem('Egg');
@@ -89,10 +89,20 @@ class InventoryModifierFunctionsTest extends TestCase
             self::makeInventory($owner, $onion),
         ];
 
-        $this->assertNull(InventoryModifierFunctions::planBulkSpicing($inventory));
+        $plan = InventoryModifierFunctions::planBulkSpicing($inventory);
+
+        $this->assertNotNull($plan);
+        $this->assertCount(2, $plan->pairs);
+        $this->assertSame(0, $plan->leftoverFoodCount);
+        $this->assertSame(0, $plan->leftoverSpiceCount);
+
+        $this->assertSame($egg, $plan->pairs[0][0]->getItem());
+        $this->assertSame($fish, $plan->pairs[1][0]->getItem());
+        $this->assertSame($onion, $plan->pairs[0][1]->getItem());
+        $this->assertSame($onion, $plan->pairs[1][1]->getItem());
     }
 
-    public function testMismatchedSpiceTypesReturnsNull(): void
+    public function testUniformFoodTypesWithMixedSpicesExactCountCreatesPlan(): void
     {
         $owner = new User('Tester', 'tester@example.com');
         $egg = self::makeFoodItem('Egg');
@@ -101,6 +111,60 @@ class InventoryModifierFunctionsTest extends TestCase
 
         $inventory = [
             self::makeInventory($owner, $egg),
+            self::makeInventory($owner, $egg),
+            self::makeInventory($owner, $onion),
+            self::makeInventory($owner, $garlic),
+        ];
+
+        $plan = InventoryModifierFunctions::planBulkSpicing($inventory);
+
+        $this->assertNotNull($plan);
+        $this->assertCount(2, $plan->pairs);
+        $this->assertSame(0, $plan->leftoverFoodCount);
+        $this->assertSame(0, $plan->leftoverSpiceCount);
+
+        $this->assertSame($egg, $plan->pairs[0][0]->getItem());
+        $this->assertSame($egg, $plan->pairs[1][0]->getItem());
+        $this->assertSame($onion, $plan->pairs[0][1]->getItem());
+        $this->assertSame($garlic, $plan->pairs[1][1]->getItem());
+    }
+
+    public function testUniformFoodTypesWithMixedSpicesAndMoreFoodsCreatesPlan(): void
+    {
+        $owner = new User('Tester', 'tester@example.com');
+        $egg = self::makeFoodItem('Egg');
+        $onion = self::makeSpiceItem('Onion');
+        $garlic = self::makeSpiceItem('Garlic');
+
+        $inventory = [
+            self::makeInventory($owner, $egg),
+            self::makeInventory($owner, $egg),
+            self::makeInventory($owner, $egg),
+            self::makeInventory($owner, $onion),
+            self::makeInventory($owner, $garlic),
+        ];
+
+        $plan = InventoryModifierFunctions::planBulkSpicing($inventory);
+
+        $this->assertNotNull($plan);
+        $this->assertCount(2, $plan->pairs);
+        $this->assertSame(1, $plan->leftoverFoodCount);
+        $this->assertSame(0, $plan->leftoverSpiceCount);
+
+        $this->assertSame($egg, $plan->pairs[0][0]->getItem());
+        $this->assertSame($egg, $plan->pairs[1][0]->getItem());
+        $this->assertSame($onion, $plan->pairs[0][1]->getItem());
+        $this->assertSame($garlic, $plan->pairs[1][1]->getItem());
+    }
+
+    public function testUniformFoodTypesWithMixedSpicesAndMoreSpicesReturnsNull(): void
+    {
+        $owner = new User('Tester', 'tester@example.com');
+        $egg = self::makeFoodItem('Egg');
+        $onion = self::makeSpiceItem('Onion');
+        $garlic = self::makeSpiceItem('Garlic');
+
+        $inventory = [
             self::makeInventory($owner, $egg),
             self::makeInventory($owner, $onion),
             self::makeInventory($owner, $garlic),
@@ -183,7 +247,25 @@ class InventoryModifierFunctionsTest extends TestCase
         }
     }
 
-    public function testMismatchedFoodTypesIsAmbiguous(): void
+    public function testMixedFoodAndSpiceTypesIsAmbiguous(): void
+    {
+        $owner = new User('Tester', 'tester@example.com');
+        $egg = self::makeFoodItem('Egg');
+        $fish = self::makeFoodItem('Fish');
+        $onion = self::makeSpiceItem('Onion');
+        $garlic = self::makeSpiceItem('Garlic');
+
+        $inventory = [
+            self::makeInventory($owner, $egg),
+            self::makeInventory($owner, $fish),
+            self::makeInventory($owner, $onion),
+            self::makeInventory($owner, $garlic),
+        ];
+
+        $this->assertTrue(InventoryModifierFunctions::isAmbiguousBulkSpicingAttempt($inventory));
+    }
+
+    public function testMixedFoodTypesWithTooFewUniformSpicesIsAmbiguous(): void
     {
         $owner = new User('Tester', 'tester@example.com');
         $egg = self::makeFoodItem('Egg');
@@ -192,15 +274,18 @@ class InventoryModifierFunctionsTest extends TestCase
 
         $inventory = [
             self::makeInventory($owner, $egg),
+            self::makeInventory($owner, $egg),
+            self::makeInventory($owner, $fish),
             self::makeInventory($owner, $fish),
             self::makeInventory($owner, $onion),
             self::makeInventory($owner, $onion),
         ];
 
+        $this->assertNull(InventoryModifierFunctions::planBulkSpicing($inventory));
         $this->assertTrue(InventoryModifierFunctions::isAmbiguousBulkSpicingAttempt($inventory));
     }
 
-    public function testMismatchedSpiceTypesIsAmbiguous(): void
+    public function testUniformFoodTypesWithMixedSpicesAndMoreSpicesIsAmbiguous(): void
     {
         $owner = new User('Tester', 'tester@example.com');
         $egg = self::makeFoodItem('Egg');
@@ -208,7 +293,6 @@ class InventoryModifierFunctionsTest extends TestCase
         $garlic = self::makeSpiceItem('Garlic');
 
         $inventory = [
-            self::makeInventory($owner, $egg),
             self::makeInventory($owner, $egg),
             self::makeInventory($owner, $onion),
             self::makeInventory($owner, $garlic),

--- a/docs/tickets/bulk-apply-spices.md
+++ b/docs/tickets/bulk-apply-spices.md
@@ -1,0 +1,36 @@
+# Bulk-Apply Spices
+
+## Context
+**Current behavior**: Cook/combine currently handles one food item and one spice item at a time. The action is not designed to infer intent across a multi-item batch selection.
+**New behavior**: This ticket adds a single, unambiguous batch-spicing flow for matching food and matching spice selections, with rejection and confirmation states when intent is unclear or mixed.
+
+## What will be true
+
+- Selecting multiple food items and multiple spice items and using cook/combine can apply each spice to a food in a single action, when the player's intent is unambiguous.
+- Bulk-spicing only proceeds when all selected food items are the same type AND all selected spice items are the same type. If the foods aren't all the same, or the spices aren't all the same, no spicing happens — even if the counts would otherwise line up cleanly (for example, six identical unspiced foods with three Spicy Spices and three Onion Powders is ambiguous and nothing gets spiced).
+- When all selected food items are the same type, all selected spice items are the same type, and at least as many food items as spice items were selected, every selected spice gets applied to a different one of those food items.
+- When all selected food items are the same type, all selected spice items are the same type, and at least as many spice items as food items were selected, every selected food item receives one of the spices.
+- If exactly as many food items as spice items were selected, every food item ends up spiced and no spice is left over.
+- If more foods were selected than spices, the extra foods remain unspiced and no spices are left over.
+- If more spices were selected than foods, every food ends up spiced and the extra spices remain unused.
+- After a successful bulk-spicing action, the player sees one of these friendly confirmation messages:
+  - Exact match: "All `<number>` of those `<food>` now have the `<spice>` spice! Batch-prepping FTW!"
+  - More foods than spices: "`<number>` of those `<food>` now have the `<spice>` spice - but there wasn't enough for the last `<count>` `<food>` so they're plain for now."
+  - More spices than foods: "All `<number>` of those `<food>` now have the `<spice>` spice! You have `<count>` `<spice>` spices leftover."
+- If the selected food items aren't all the same type, no spicing happens.
+- If any food item in the selection already has a spice applied, no spicing happens for the whole selection — even if the rest of the selection would otherwise be unambiguous.
+- In every other case where intent can't be determined this way, no spicing happens, and the player sees the message: "Hmm, this is some complicated seasoning you're requesting. Let's not."
+- Bulk-spicing works anywhere cook/combine is available today (for example the House and the Basement); it isn't a separate feature or a separate location.
+
+## Out of scope
+
+- Applying one shared spice across a mix of different food types (for example, one Fish, one Egg, and one Chocolate bar all receiving the same spice). All foods in a bulk-spicing selection must be the same type, even when the spices are the ones providing the matching quantity.
+- Applying a mix of different spice types across a set of identical foods (for example, three Spicy Spices and three Onion Powders applied across six identical unspiced foods). All spices in a bulk-spicing selection must be the same type too, even when the food count and spice count line up evenly.
+- Any new handling for selections that mix in items that are neither food nor spice. The whole action already gets rejected in that case, and that existing behavior is relied on rather than replaced.
+- Partially spicing a selection that includes an already-spiced food. No subset of the selection gets spiced in that case; the whole batch is treated as ambiguous.
+
+## Invariants
+
+- Applying a single spice to a single food continues to work exactly as it does today.
+- No other cook/combine behavior changes as part of this.
+- A food item never ends up with more than one spice applied to it, before or after this feature exists.

--- a/docs/tickets/bulk-apply-spices.md
+++ b/docs/tickets/bulk-apply-spices.md
@@ -1,31 +1,43 @@
 # Bulk-Apply Spices
 
 ## Context
-**Current behavior**: Cook/combine currently handles one food item and one spice item at a time. The action is not designed to infer intent across a multi-item batch selection.
-**New behavior**: This ticket adds a single, unambiguous batch-spicing flow for matching food and matching spice selections, with rejection and confirmation states when intent is unclear or mixed.
+**Existing behavior**: Cook/combine handles one food item and one spice item at a time. That behavior is already implemented and remains unchanged.
+
+**Enhancement**: This ticket adds batch spicing when the relationship between selected foods and spices is unambiguous. A batch is unambiguous when either all selected foods are the same type or all selected spices are the same type, subject to the count rules below. A batch with both mixed food types and mixed spice types remains ambiguous.
 
 ## What will be true
 
 - Selecting multiple food items and multiple spice items and using cook/combine can apply each spice to a food in a single action, when the player's intent is unambiguous.
-- Bulk-spicing only proceeds when all selected food items are the same type AND all selected spice items are the same type. If the foods aren't all the same, or the spices aren't all the same, no spicing happens — even if the counts would otherwise line up cleanly (for example, six identical unspiced foods with three Spicy Spices and three Onion Powders is ambiguous and nothing gets spiced).
-- When all selected food items are the same type, all selected spice items are the same type, and at least as many food items as spice items were selected, every selected spice gets applied to a different one of those food items.
-- When all selected food items are the same type, all selected spice items are the same type, and at least as many spice items as food items were selected, every selected food item receives one of the spices.
+- When selected foods are all the same type, the selected spices may be the same type or different types, provided there are no more spices than foods.
+- When all selected food items are the same type and at least as many food items as spice items were selected, every selected spice gets applied to a different one of those food items, regardless of whether the selected spice items are the same or different types.
+- When selected spices are all the same type, the selected foods may be the same type or different types, provided there are at least as many spices as foods.
+- When all selected spice items are the same type and at least as many spice items as food items were selected, every selected food item receives one of the spices, regardless of whether the selected food items are the same or different types.
+- When selected foods are all the same type and selected spices are all the same type, the batch is unambiguous regardless of their relative counts:
+
+  | Selected foods | Selected spices | Result |
+  | --- | --- | --- |
+  | 4 Oranges | 2 Spicy Spices | Two Oranges receive Spicy Spice; two remain plain. |
+  | 4 Oranges | 4 Spicy Spices | Every Orange receives Spicy Spice. |
+  | 4 Oranges | 6 Spicy Spices | Every Orange receives Spicy Spice; two Spicy Spices remain unused. |
+
 - If exactly as many food items as spice items were selected, every food item ends up spiced and no spice is left over.
-- If more foods were selected than spices, the extra foods remain unspiced and no spices are left over.
-- If more spices were selected than foods, every food ends up spiced and the extra spices remain unused.
+- If more foods were selected than spices and all food items are the same type, the extra foods remain unspiced and no spices are left over.
+- If more spices were selected than foods and all spice items are the same type, every food ends up spiced and the extra spices remain unused.
 - After a successful bulk-spicing action, the player sees one of these friendly confirmation messages:
-  - Exact match: "All `<number>` of those `<food>` now have the `<spice>` spice! Batch-prepping FTW!"
-  - More foods than spices: "`<number>` of those `<food>` now have the `<spice>` spice - but there wasn't enough for the last `<count>` `<food>` so they're plain for now."
-  - More spices than foods: "All `<number>` of those `<food>` now have the `<spice>` spice! You have `<count>` `<spice>` spices leftover."
-- If the selected food items aren't all the same type, no spicing happens.
+  - Exact match: "`<quantity list of foods>` are now seasoned: `<quantity list of applied spices>`! Batch-prepping FTW!"
+  - More foods than spices: "`<quantity list of spiced foods>` are now seasoned: `<quantity list of applied spices>` - but there wasn't enough for the last `<quantity list of unspiced foods>` so they're plain for now."
+  - More spices than foods: "`<quantity list of foods>` are now seasoned: `<quantity list of applied spices>`! You have `<quantity list of leftover spices>` leftover."
+- Every quantity list reuses the existing recipe confirmation formatter.
+- Quantity lists report totals by item type and do not identify individual food-to-spice pairings.
 - If any food item in the selection already has a spice applied, no spicing happens for the whole selection — even if the rest of the selection would otherwise be unambiguous.
+- If the selected food items are different types and the selected spice items are different types, no spicing happens.
+- If selected food items are different types and fewer spices than foods are selected, no spicing happens.
+- If more spices than foods are selected and the spices are not all the same type, no spicing happens.
 - In every other case where intent can't be determined this way, no spicing happens, and the player sees the message: "Hmm, this is some complicated seasoning you're requesting. Let's not."
 - Bulk-spicing works anywhere cook/combine is available today (for example the House and the Basement); it isn't a separate feature or a separate location.
 
 ## Out of scope
 
-- Applying one shared spice across a mix of different food types (for example, one Fish, one Egg, and one Chocolate bar all receiving the same spice). All foods in a bulk-spicing selection must be the same type, even when the spices are the ones providing the matching quantity.
-- Applying a mix of different spice types across a set of identical foods (for example, three Spicy Spices and three Onion Powders applied across six identical unspiced foods). All spices in a bulk-spicing selection must be the same type too, even when the food count and spice count line up evenly.
 - Any new handling for selections that mix in items that are neither food nor spice. The whole action already gets rejected in that case, and that existing behavior is relied on rather than replaced.
 - Partially spicing a selection that includes an already-spiced food. No subset of the selection gets spiced in that case; the whole batch is treated as ambiguous.
 


### PR DESCRIPTION
## Why

Because bulk-spicing is useful!!!

The goal is that spicing in batches feels just like cooking/combining in batches, and that the game never does anything surprising. Bulk-spicing only kicks in when the selection is obviously intentional, so the rules stay clear, predictable, and easy to reason about while still helping players prep efficiently.

## Notes

Rules that stay in place:

All foods in a batch must match or all spices in a batch must match (no longer necessarily both).
No food can end up with more than one spice.
If any selected food is already spiced, the whole batch is rejected — no subset gets spiced.
If both foods and spices are mixed, the batch is rejected.
The existing single-item cook/combine behavior is unchanged.

Successful batch cases (when foods are all one type and spices are all one type, any relative count works):

exact counts: every food gets spiced, nothing left over,
more foods than spices: the extra foods stay plain,
more spices than foods: every food gets one spice, extras remain unused.

On success the player gets one of these confirmations. Quantities use the existing recipe confirmation formatter and report totals by item type — no individual food-to-spice pairings:

Exact match: "<foods> are now seasoned: <spices>! Batch-prepping FTW!"
More foods than spices: "<spiced foods> are now seasoned: <spices> - but there wasn't enough for the last <unspiced foods> so they're plain for now."
More spices than foods: "<foods> are now seasoned: <spices>! You have <leftover spices> leftover."

When intent can't be determined, nothing happens and the game says: "Hmm, this is some complicated seasoning you're requesting. Let's not."

## Invariants / out of scope
Selections that mix in non-food, non-spice items are still rejected wholesale by existing behavior (unchanged, relied on rather than replaced).
A selection containing an already-spiced food is never partially spiced.
Single spice with a single food behaves exactly as it does today; no other cook/combine behavior changes.